### PR TITLE
Close transport on unregister

### DIFF
--- a/aiolifx/aiolifx.py
+++ b/aiolifx/aiolifx.py
@@ -122,6 +122,9 @@ class Device(aio.DatagramProtocol):
         print('Error received:', exc)
 
     def connection_lost(self, exc):
+        if self.transport:
+            self.transport.close()
+            self.transport = None
         if self.parent:
             self.parent.unregister(self)
             


### PR DESCRIPTION
This plugs a file descriptor leak discovered by @mihalski in home-assistant/home-assistant#6985

To reproduce:

1. Start the example cli program
2. Power off a bulb
3. Send a command to that bulb, so that it unregisters
4. Power on the bulb and let it register
5. Observe (for example with ```lsof```) that two UDP sockets now exist for that bulb

What do you think?