### PR TITLE
Test for transport before sending to it

### DIFF
--- a/aiolifx/aiolifx.py
+++ b/aiolifx/aiolifx.py
@@ -137,7 +137,8 @@ class Device(aio.DatagramProtocol):
         sent_msg_count = 0
         sleep_interval = 0.05 if num_repeats > 20 else 0
         while(sent_msg_count < num_repeats):
-            self.transport.sendto(msg.packed_message)
+            if self.transport:
+                self.transport.sendto(msg.packed_message)
             sent_msg_count += 1
             await aio.sleep(sleep_interval) # Max num of messages device can handle is 20 per second.
 
@@ -155,7 +156,8 @@ class Device(aio.DatagramProtocol):
             event = aio.Event()
             self.message[msg.seq_num][1]= event
             attempts += 1
-            self.transport.sendto(msg.packed_message)
+            if self.transport:
+                self.transport.sendto(msg.packed_message)
             try:
                 myresult = await aio.wait_for(event.wait(),timeout_secs)
                 break


### PR DESCRIPTION
A device can unregister at any time and clients have to do a lot of
bookkeeping to avoid warnings because they sent to a device that just
disappeared.

This change allows clients to send messages into the void left by `unregister`.

It is a bit naive as the resend/unregister logic is still invoked for each
unsent message but no harm should be caused by this extra work.