### PR TITLE
Use bytes for payload concatenation

### DIFF
--- a/aiolifx/msgtypes.py
+++ b/aiolifx/msgtypes.py
@@ -469,7 +469,7 @@ class MultiZoneStateMultiZone(Message):
         index = little_endian(bitstring.pack("8", self.index))
         payload = count + index
         for color in self.color:
-            payload += "".join(little_endian(bitstring.pack("16", field)) for field in color)
+            payload += b"".join(little_endian(bitstring.pack("16", field)) for field in color)
         return payload
 
 class MultiZoneStateZone(Message): #503


### PR DESCRIPTION
The `b` prefix seems to have been missed in this single place. The problem was reported in home-assistant/home-assistant#7224 but I do not have a LIFX Z to validate.