### PR TITLE
Treat StateWifiInfo.reserved1 as signed

### DIFF
--- a/aiolifx/msgtypes.py
+++ b/aiolifx/msgtypes.py
@@ -104,7 +104,7 @@ class StateWifiInfo(Message):
         signal = little_endian(bitstring.pack("32", self.signal))
         tx = little_endian(bitstring.pack("32", self.tx))
         rx = little_endian(bitstring.pack("32", self.rx))
-        reserved1 = little_endian(bitstring.pack("16", self.reserved1))
+        reserved1 = little_endian(bitstring.pack("int:16", self.reserved1))
         payload = signal + tx + rx + reserved1
         return payload
 


### PR DESCRIPTION
I found the below traceback in my log this morning (and I don't even use that message).

This commit should fix it. It is still untested, though, and I did not go through all messages to check if there are more instances of this problem.

```
Traceback (most recent call last):
  File "/Users/homeassistant/.homeassistant/deps/bitstring.py", line 1219, in _init_with_token
    b = cls(**{_tokenname_to_initialiser[name]: value})
KeyError: 'uint'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/homeassistant/.homeassistant/deps/bitstring.py", line 817, in _initialise
    init_without_length_or_offset[k](self, v)
KeyError: 'uint'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/Cellar/python3/3.6.0/Frameworks/Python.framework/Versions/3.6/lib/python3.6/asyncio/events.py", line 126, in _run
    self._callback(*self._args)
  File "/usr/local/Cellar/python3/3.6.0/Frameworks/Python.framework/Versions/3.6/lib/python3.6/asyncio/selector_events.py", line 1078, in _read_ready
    self._protocol.datagram_received(data, addr)
  File "/Users/homeassistant/.homeassistant/deps/aiolifx/aiolifx.py", line 562, in datagram_received
    response = unpack_lifx_message(data)
  File "/Users/homeassistant/.homeassistant/deps/aiolifx/unpack.py", line 68, in unpack_lifx_message
    message = StateWifiInfo(target_addr, source_id, seq_num, payload, ack_requested, response_requested)
  File "/Users/homeassistant/.homeassistant/deps/aiolifx/msgtypes.py", line 97, in __init__
    super(StateWifiInfo, self).__init__(MSG_IDS[StateWifiInfo], target_addr, source_id, seq_num, ack_requested, response_requested)
  File "/Users/homeassistant/.homeassistant/deps/aiolifx/message.py", line 43, in __init__
    self.packed_message = self.generate_packed_message()
  File "/Users/homeassistant/.homeassistant/deps/aiolifx/message.py", line 46, in generate_packed_message
    self.payload = self.get_payload()
  File "/Users/homeassistant/.homeassistant/deps/aiolifx/msgtypes.py", line 107, in get_payload
    reserved1 = little_endian(bitstring.pack("16", self.reserved1))
  File "/Users/homeassistant/.homeassistant/deps/bitstring.py", line 4224, in pack
    s._append(BitStream._init_with_token(name, length, value))
  File "/Users/homeassistant/.homeassistant/deps/bitstring.py", line 1224, in _init_with_token
    b = cls(**{name: int(value), 'length': token_length})
  File "/Users/homeassistant/.homeassistant/deps/bitstring.py", line 4133, in __new__
    x._initialise(auto, length, offset, **kwargs)
  File "/Users/homeassistant/.homeassistant/deps/bitstring.py", line 822, in _initialise
    init_with_length_only[k](self, v, length)
  File "/Users/homeassistant/.homeassistant/deps/bitstring.py", line 1369, in _setuint
    raise CreationError("uint cannot be initialsed by a negative number.")
bitstring.CreationError: uint cannot be initialsed by a negative number.
```
