### PR TITLE
Ignore response.origin

### DIFF
--- a/aiolifx/aiolifx.py
+++ b/aiolifx/aiolifx.py
@@ -102,7 +102,7 @@ class Device(aio.DatagramProtocol):
             self.lastmsg=datetime.datetime.now()
             response_type,myevent,callb = self.message[response.seq_num]
             if type(response) == response_type:
-                if response.origin == 1 and response.source_id == self.source_id:
+                if response.source_id == self.source_id:
                     self.ip_addr = addr
                     if "State" in response.__class__.__name__:
                         setmethod="resp_set_"+response.__class__.__name__.replace("State","").lower()

--- a/aiolifx/aiolifx34.py
+++ b/aiolifx/aiolifx34.py
@@ -102,7 +102,7 @@ class Device(aio.DatagramProtocol):
             self.lastmsg=datetime.datetime.now()
             response_type,myevent,callb = self.message[response.seq_num]
             if type(response) == response_type:
-                if response.origin == 1 and response.source_id == self.source_id:
+                if response.source_id == self.source_id:
                     self.ip_addr = addr
                     if "State" in response.__class__.__name__:
                         setmethod="resp_set_"+response.__class__.__name__.replace("State","").lower()


### PR DESCRIPTION
This field is documented to always be zero. Yet, so far it wasn't. But now it
is. Better just leave it alone.