### PR TITLE
Unregister timeout

### DIFF
--- a/aiolifx/aiolifx34.py
+++ b/aiolifx/aiolifx34.py
@@ -68,6 +68,7 @@ class Device(aio.DatagramProtocol):
         self.registered = False
         self.retry_count = DEFAULT_ATTEMPTS
         self.timeout = DEFAULT_TIMEOUT
+        self.unregister_timeout = DEFAULT_TIMEOUT
         self.transport = None
         self.task = None
         self.seq = 0
@@ -88,7 +89,7 @@ class Device(aio.DatagramProtocol):
         self.host_firmware_build_timestamp = None
         self.wifi_firmware_version = None
         self.wifi_firmware_build_timestamp = None
-        self.lastmsg=datetime.datetime.now()-datetime.timedelta(seconds=600)
+        self.lastmsg=datetime.datetime.now()
         
     def seq_next(self):
         self.seq = ( self.seq + 1 ) % 128
@@ -105,8 +106,8 @@ class Device(aio.DatagramProtocol):
     def datagram_received(self, data, addr):
         self.register()
         response = unpack_lifx_message(data)
+        self.lastmsg=datetime.datetime.now()
         if response.seq_num in self.message:
-            self.lastmsg=datetime.datetime.now()
             response_type,myevent,callb = self.message[response.seq_num]
             if type(response) == response_type:
                 if response.source_id == self.source_id:
@@ -134,8 +135,7 @@ class Device(aio.DatagramProtocol):
     def unregister(self):
         if self.registered:
             #Only if we have not received any message recently.
-            #On slower CPU, a race condition seem to sometime occur
-            if datetime.datetime.now()-datetime.timedelta(seconds=DEFAULT_TIMEOUT) > self.lastmsg:
+            if datetime.datetime.now()-datetime.timedelta(seconds=self.unregister_timeout) > self.lastmsg:
                 self.registered = False
                 if self.parent:
                     self.parent.unregister(self)
@@ -596,7 +596,7 @@ class Light(Device):
     
 class LifxDiscovery(aio.DatagramProtocol):
 
-    def __init__(self, loop, parent=None, ipv6prefix=None, discovery_interval=DISCOVERY_INTERVAL, discovery_step=DISCOVERY_STEP):
+    def __init__(self, loop, parent=None, ipv6prefix=None, discovery_interval=DISCOVERY_INTERVAL, discovery_step=DISCOVERY_STEP, broadcast_ip=UDP_BROADCAST_IP):
         self.lights = {} #Known devices indexed by mac addresses
         self.parent = parent #Where to register new devices
         self.transport = None
@@ -606,6 +606,7 @@ class LifxDiscovery(aio.DatagramProtocol):
         self.discovery_interval = discovery_interval
         self.discovery_step = discovery_step
         self.discovery_countdown = 0
+        self.broadcast_ip = broadcast_ip
 
     def connection_made(self, transport):
         #print('started')
@@ -666,7 +667,7 @@ class LifxDiscovery(aio.DatagramProtocol):
             if self.discovery_countdown <= 0:
                 self.discovery_countdown = self.discovery_interval
                 msg = GetService(BROADCAST_MAC, self.source_id, seq_num=0, payload={}, ack_requested=False, response_requested=True)    
-                self.transport.sendto(msg.generate_packed_message(), (UDP_BROADCAST_IP, UDP_BROADCAST_PORT ))
+                self.transport.sendto(msg.generate_packed_message(), (self.broadcast_ip, UDP_BROADCAST_PORT))
             else:
                 self.discovery_countdown -= self.discovery_step
             self.loop.call_later(self.discovery_step, self.discover)


### PR DESCRIPTION
The `unregister` callback was already skipped if a message was dropped within `DEFAULT_TIMEOUT` of a received message. This PR makes the duration configurable.

This change makes sense to me now that the client is free to keep using the aiolifx Light even after it has unregistered. It specifies a grace period where the client will keep trying (for example when the user presses a physical button again after a few seconds).

I have experimented with this value and setting it to 60 seconds removes the intermittent dropouts that I was seeing. It is of course still possible to send a command that is not executed by the bulb. However, the risk is much smaller when it is only the bulb that goes unresponsive, not aiolifx.

(I am also updating aiolifx34.py in this PR as it seems that the `broadcast_ip` changes were not applied in 0.5.0)