### PR TITLE
Fix message size calculation

### DIFF
--- a/aiolifx/message.py
+++ b/aiolifx/message.py
@@ -95,7 +95,7 @@ class Message(object):
         return protocol_header
 
     def get_msg_size(self):
-        payload_size_bytes = len(self.payload)/8
+        payload_size_bytes = len(self.payload)
         return HEADER_SIZE_BYTES + payload_size_bytes
 
     def __str__(self):


### PR DESCRIPTION
It was reported that the Home Assistant LIFX integration is broken with the upcoming Gen2 firmware version 1.22: home-assistant/home-assistant#8284. This firmware is so far only available from LIFX support so it's not a big issue yet but in a few days it will be.

I have found out that the problem is that the message size is calculated wrongly and apparently the LIFX firmware has started to check that.

CC: @mclarkk because I think this bug was inherited from lifxlan