### PR TITLE
Fix off-by-one error in get_color_zones

### DIFF
--- a/aiolifx/aiolifx.py
+++ b/aiolifx/aiolifx.py
@@ -513,7 +513,7 @@ class Light(Device):
     # Multizone
     def get_color_zones(self, start_index, end_index=None, callb=None):
         if end_index is None:
-            end_index = start_index + 8
+            end_index = start_index + 7
         args = {
             "start_index": start_index,
             "end_index": end_index,

--- a/aiolifx/aiolifx34.py
+++ b/aiolifx/aiolifx34.py
@@ -515,7 +515,7 @@ class Light(Device):
     # Multizone
     def get_color_zones(self, start_index, end_index=None, callb=None):
         if end_index is None:
-            end_index = start_index + 8
+            end_index = start_index + 7
         args = {
             "start_index": start_index,
             "end_index": end_index,


### PR DESCRIPTION
The end_index is the last zone to include, not the first zone to exclude.
This error caused LIFX Z to send an extra response message.