### PR TITLE
Reword Value as Brightness

### DIFF
--- a/examples/lifx-cli.py
+++ b/examples/lifx-cli.py
@@ -144,7 +144,7 @@ def readin():
         print("Select Function for {}:".format(MyBulbs.boi.label))
         print("\t[1]\tPower (0 or 1)")
         print("\t[2]\tWhite (Brigthness Temperature)")
-        print("\t[3]\tColour (Hue Saturation Value)")
+        print("\t[3]\tColour (Hue Saturation Brightness)")
         print("\t[4]\tInfo")
         print("\t[5]\tFirmware")
         print("\t[6]\tWifi")


### PR DESCRIPTION
This matches how it is used elsewhere (and is easier to understand).