### PR TITLE
Always reconnect when rediscovering a light

### DIFF
--- a/aiolifx/aiolifx.py
+++ b/aiolifx/aiolifx.py
@@ -1192,9 +1192,8 @@ class LifxDiscovery(aio.DatagramProtocol):
             # rediscovered
             light = self.lights[mac_addr]
 
-            # nothing changed, just register again
-            if light.ip_addr == remote_ip and light.port == remote_port:
-                light.register()
+            # nothing to do
+            if light.registered:
                 return
 
             light.cleanup()


### PR DESCRIPTION
I have been fighting an issue where the `Device` method `datagram_received` stopped being called. It turns out that some firmwares (tested with LIFX Mini Color v3.40) combined with uvloop on Linux can cause this behavior, for example due to a power cycle. The event loop simply stops polling the socket when an error is detected.

This PR changes the reconnect logic so the socket is always recreated, even if its parameters are identical to the unregistered socket. This makes the event loop start polling for data once again.