### PR TITLE
Add LifxScan class for finding networks with bulbs

### DIFF
--- a/aiolifx/__init__.py
+++ b/aiolifx/__init__.py
@@ -1,4 +1,4 @@
-from .aiolifx import LifxDiscovery
+from .aiolifx import LifxDiscovery, LifxScan
 from .message import *
 from .msgtypes import *
 from .unpack import unpack_lifx_message

--- a/examples/lifx-cli.py
+++ b/examples/lifx-cli.py
@@ -161,6 +161,13 @@ def readin():
     print("Your choice: ", end='',flush=True)
   
 
+async def scan(loop, discovery):
+    scanner = alix.LifxScan(loop)
+    ips = await scanner.scan()
+    print("Hit \"Enter\" to start")
+    print("Use Ctrl-C to quit")
+    discovery.start(listen_ip=ips[0])
+
 
 MyBulbs= bulbs()
 loop = aio.get_event_loop()
@@ -168,9 +175,7 @@ discovery = alix.LifxDiscovery(loop, MyBulbs)
 
 try:
     loop.add_reader(sys.stdin,readin)
-    discovery.start()
-    print("Hit \"Enter\" to start")
-    print("Use Ctrl-C to quit")
+    loop.create_task(scan(loop, discovery))
     loop.run_forever()
 except:
     pass

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(name='aiolifx',
     license='MIT',
     install_requires=[
     "bitstring",
+    "ifaddr",
     ],
     # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
     classifiers=[


### PR DESCRIPTION
When a machine has multiple network interfaces, I need a way to find the one where LIFX bulbs are available.

This new class does that by starting discovery on all interfaces and returning the local address(es) of the ones that receive a response within one second.
