### PR TITLE
Avoid LifxScan exception when no adapters are found

### DIFF
--- a/aiolifx/aiolifx.py
+++ b/aiolifx/aiolifx.py
@@ -1271,6 +1271,9 @@ class LifxScan:
         adapters = await self.loop.run_in_executor(None, ifaddr.get_adapters)
         ips = [ip.ip for adapter in ifaddr.get_adapters() for ip in adapter.ips if ip.is_IPv4]
 
+        if not ips:
+            return []
+
         tasks = []
         discoveries = []
         for ip in ips:


### PR DESCRIPTION
Apparently `ifaddr` will not find any network adapters in some rare configurations.

This PR improves the error handling in that case, avoiding [this exception](https://community.home-assistant.io/t/lifx-integration-implementation-issues/82436):

```text
2018-12-02 15:32:21 ERROR (MainThread) [homeassistant.components.light] Error while setting up platform lifx
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/homeassistant/helpers/entity_platform.py", line 128, in _async_setup_platform
    SLOW_SETUP_MAX_WAIT, loop=hass.loop)
  File "/usr/local/lib/python3.6/asyncio/tasks.py", line 358, in wait_for
    return fut.result()
  File "/usr/local/lib/python3.6/site-packages/homeassistant/components/light/lifx.py", line 151, in async_setup_entry
    lifx_ip_addresses = await aiolifx().LifxScan(hass.loop).scan()
  File "/mnt/config/deps/lib/python3.6/site-packages/aiolifx/aiolifx.py", line 1283, in scan
    (done, pending) = await aio.wait(tasks, timeout=timeout)
  File "/usr/local/lib/python3.6/asyncio/tasks.py", line 304, in wait
    raise ValueError('Set of coroutines/Futures is empty.')
ValueError: Set of coroutines/Futures is empty.```
```
