### PR TITLE
Optimize message generation

### DIFF
--- a/aiolifx/message.py
+++ b/aiolifx/message.py
@@ -40,7 +40,17 @@ class Message(object):
 
         self.payload_fields = [] # tuples of ("label", value)
 
-        self.packed_message = self.generate_packed_message()
+        self._packed_message = None
+
+    @property
+    def packed_message(self):
+        if self._packed_message is None:
+            self._packed_message = self.generate_packed_message()
+        return self._packed_message
+
+    @packed_message.setter
+    def packed_message(self, value):
+        self._packed_message = value
 
     def generate_packed_message(self):
         self.payload = self.get_payload()

--- a/aiolifx/message.py
+++ b/aiolifx/message.py
@@ -130,9 +130,4 @@ def convert_MAC_to_int(addr):
     return int(addr_str, 16)    
 
 def little_endian(bs):
-    shifts = [i*8 for i in range(int(len(bs)/8))]
-    int_bytes_little_endian = [int(bs.uintbe >> i & 0xff) for i in shifts]
-    packed_message_little_endian = b""
-    for b in int_bytes_little_endian:
-        packed_message_little_endian += struct.pack("B", b)
-    return packed_message_little_endian
+    return bytes(reversed(bs.bytes))

--- a/aiolifx/message.py
+++ b/aiolifx/message.py
@@ -2,7 +2,6 @@
 # Author: Meghan Clark
 
 import struct
-import bitstring
 import binascii
 import sys
 
@@ -15,7 +14,7 @@ class Message(object):
     def __init__(self, msg_type, target_addr, source_id, seq_num, ack_requested=False, response_requested=False):
 
         # Frame
-        self.frame_format = ["uint:16", "uint:2, bool, bool, uint:12", "uint:32"]
+        self.frame_format = ["<H", "<H", "<L"]
         self.size = None                                                # 16 bits/uint16
         self.origin = 0                                                 # 2 bits/uint8, must be zero
         self.tagged = 1 if target_addr == BROADCAST_MAC else 0          # 1 bit/bool, also must be one if getservice
@@ -24,7 +23,7 @@ class Message(object):
         self.source_id = source_id                                      # 32 bits/uint32, unique ID set by client. If zero, broadcast reply requested. If non-zero, unicast reply requested.
 
         # Frame Address
-        self.frame_addr_format = ["uint:64", "uint:48", "uint:6, bool, bool", "uint:8"]
+        self.frame_addr_format = ["<Q", "<BBBBBB", "<B", "<B"]
         self.target_addr = target_addr                                  # 64 bits/uint64, either single MAC address or all zeroes for broadcast.
         self.reserved = 0                                               # 48 bits/uint8 x 6, all zero
         self.reserved = 0                                               # 6 bits, all zero
@@ -33,7 +32,7 @@ class Message(object):
         self.seq_num = seq_num                                          # 8 bits/uint8, wraparound
 
         # Protocol Header
-        self.protocol_header_format = ["uint:64", "uint:16", "uint:16"]
+        self.protocol_header_format = ["<Q", "<H", "<H"]
         self.reserved = 0                                               # 64 bits/uint64, all zero
         self.message_type = msg_type                                    # 16 bits/uint16
         self.reserved = 0                                               # 16 bits/uint16, all zero
@@ -70,15 +69,15 @@ class Message(object):
     
     # Default: No payload unless method overridden
     def get_payload(self):
-        return little_endian(bitstring.pack(""))
+        return struct.pack("")
 
     def get_frame(self):
         size_format = self.frame_format[0]
         flags_format = self.frame_format[1]
         source_id_format = self.frame_format[2]
-        size = little_endian(bitstring.pack(size_format, self.size))
-        flags = little_endian(bitstring.pack(flags_format, self.origin, self.tagged, self.addressable, self.protocol))
-        source_id = little_endian(bitstring.pack(source_id_format, self.source_id))
+        size = struct.pack(size_format, self.size)
+        flags = struct.pack(flags_format, ((self.origin & 0b11) << 14) | ((self.tagged & 0b1) << 13) | ((self.addressable & 0b1) << 12) | (self.protocol & 0b111111111111))
+        source_id = struct.pack(source_id_format, self.source_id)
         frame = size + flags + source_id
         return frame
 
@@ -87,10 +86,10 @@ class Message(object):
         reserved_48_format = self.frame_addr_format[1]
         response_flags_format = self.frame_addr_format[2]
         seq_num_format = self.frame_addr_format[3]
-        mac_addr = little_endian(bitstring.pack(mac_addr_format, convert_MAC_to_int(self.target_addr)))
-        reserved_48 = little_endian(bitstring.pack(reserved_48_format, self.reserved))
-        response_flags = little_endian(bitstring.pack(response_flags_format, self.reserved, self.ack_requested, self.response_requested))
-        seq_num = little_endian(bitstring.pack(seq_num_format, self.seq_num))
+        mac_addr = struct.pack(mac_addr_format, convert_MAC_to_int(self.target_addr))
+        reserved_48 = struct.pack(reserved_48_format, *([self.reserved]*6))
+        response_flags = struct.pack(response_flags_format, ((self.reserved & 0b111111) << 2) | ((self.ack_requested & 0b1) << 1) | (self.response_requested & 0b1))
+        seq_num = struct.pack(seq_num_format, self.seq_num)
         frame_addr = mac_addr + reserved_48 + response_flags + seq_num
         return frame_addr
 
@@ -98,9 +97,9 @@ class Message(object):
         reserved_64_format = self.protocol_header_format[0]
         message_type_format = self.protocol_header_format[1]
         reserved_16_format = self.protocol_header_format[2]
-        reserved_64 = little_endian(bitstring.pack(reserved_64_format, self.reserved))
-        message_type = little_endian(bitstring.pack(message_type_format, self.message_type))
-        reserved_16 = little_endian(bitstring.pack(reserved_16_format, self.reserved))
+        reserved_64 = struct.pack(reserved_64_format, self.reserved)
+        message_type = struct.pack(message_type_format, self.message_type)
+        reserved_16 = struct.pack(reserved_16_format, self.reserved)
         protocol_header = reserved_64 + message_type + reserved_16
         return protocol_header
 

--- a/aiolifx/msgtypes.py
+++ b/aiolifx/msgtypes.py
@@ -419,9 +419,7 @@ class LightState(Message):
         color = b"".join(little_endian(bitstring.pack("uint:16", field)) for field in self.color)
         reserved1 = little_endian(bitstring.pack("int:16", self.reserved1))
         power_level = little_endian(bitstring.pack("uint:16", self.power_level))
-        label = b"".join(little_endian(bitstring.pack("uint:8", c)) for c in self.label)
-        label_padding = b"".join(little_endian(bitstring.pack("uint:8", 0)) for i in range(32-len(self.label)))
-        label += label_padding
+        label = self.label.ljust(32, b"\0")
         reserved2 = little_endian(bitstring.pack("uint:64", self.reserved1))
         payload = color + reserved1 + power_level + label + reserved2
         return payload


### PR DESCRIPTION
I have profiled (py-spy) Home Assistant and found that aiolifx is taking up a lot of my CPU usage. I went ahead and optimized the hot paths in my setup:

* Construct the message header with `struct`, not `bitstring` (much faster)
* Only generate a packed message when accessed (so usually not for received messages)
* Simplify two methods working on bytes

With these changes, aiolifx all but disappears from the flame graph.