### PR TITLE
Fix host_firmware_version issues

### DIFF
--- a/aiolifx/aiolifx.py
+++ b/aiolifx/aiolifx.py
@@ -685,8 +685,8 @@ class Device(aio.DatagramProtocol):
     def resp_set_hostfirmware(self, resp):
         """Default callback for get_hostfirmware"""
         if resp:
-            self.host_firmware_version = float(
-                str(str(resp.version >> 16) + "." + str(resp.version & 0xFF))
+            self.host_firmware_version = (
+                str(resp.version >> 16) + "." + str(resp.version & 0xFFFF)
             )
             self.host_firmware_build_timestamp = resp.build
 


### PR DESCRIPTION
Hello, thanks for making the release yesterday. A new issue has unfortunately surfaced.

We have a problem identifying the firmware version because it is converted to a `float`. This means that a current version like `3.70` is identical to an old version `3.7` and that confuses the update logic.

I also noticed that the minor version is really 16 bits, not 8 bits. AFAIK, this has not been an issue because minor versions have not reached 256 yet. https://lan.developer.lifx.com/docs/information-messages#statewififirmware---packet-19

This PR fixes both issues. It is a breaking change since the type of `self.host_firmware_version` changes from `float` to `str`.