### PR TITLE
Adds support for HEV Light Control (LIFX Clean)

### DIFF
--- a/aiolifx/__main__.py
+++ b/aiolifx/__main__.py
@@ -4,6 +4,7 @@
 # This application is an example on how to use aiolifx
 #
 # Copyright (c) 2016 François Wautier
+# Copyright (c) 2022 Michael Farrell <micolous+git@gmail.com>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -176,6 +177,63 @@ def readin():
                         print(
                             "Error: For pulse you must indicate hue (0-360), saturation (0-100) and brightness (0-100))\n"
                         )
+                elif int(lov[0]) == 9:
+                    # HEV cycle
+                    if len(lov) == 1:
+                        # Get current state
+                        print("Getting current HEV state")
+                        MyBulbs.boi.get_hev_cycle(
+                            callb=lambda _, r: print(
+                                f"\nHEV: duration={r.duration}, "
+                                f"remaining={r.remaining}, "
+                                f"last_power={r.last_power}"))
+                        MyBulbs.boi.get_last_hev_cycle_result(
+                            callb=lambda _, r: print(
+                                f"\nHEV result: {r.result_str}"))
+
+                    elif len(lov) == 2:
+                        duration = int(lov[1])
+                        enable = duration >= 0
+                        if enable:
+                            print(f"Running HEV cycle for {duration} second(s)")
+                        else:
+                            print(f"Aborting HEV cycle")
+                            duration = 0
+                        MyBulbs.boi.set_hev_cycle(
+                            enable=enable,
+                            duration=duration,
+                            callb=lambda _, r: print(
+                                f"\nHEV: duration={r.duration}, "
+                                f"remaining={r.remaining}, "
+                                f"last_power={r.last_power}"))
+                    else:
+                        print("Error: maximum 1 argument for HEV cycle")
+                    MyBulbs.boi = None
+                elif int(lov[0]) == 10:
+                    # HEV cycle configuration
+                    if len(lov) == 1:
+                        # Get current state
+                        print("Getting current HEV configuration")
+                        MyBulbs.boi.get_hev_configuration(
+                            callb=lambda _, r: print(
+                                f"\nHEV: indication={r.indication}, "
+                                f"duration={r.duration}"))
+
+                    elif len(lov) == 3:
+                        indication = bool(int(lov[1]))
+                        duration = int(lov[2])
+                        print(f"Configuring default HEV cycle with "
+                              f"{'' if indication else 'no '}indication for "
+                              f"{duration} second(s)")
+                        MyBulbs.boi.set_hev_configuration(
+                            indication=indication,
+                            duration=duration,
+                            callb=lambda _, r: print(
+                                f"\nHEV: indication={r.indication}, "
+                                f"duration={r.duration}"))
+                    else:
+                        print("Error: 0 or 2 arguments for HEV config")
+                    MyBulbs.boi = None
             # except:
             # print ("\nError: Selection must be a number.\n")
         else:
@@ -199,6 +257,8 @@ def readin():
         print("\t[6]\tWifi")
         print("\t[7]\tUptime")
         print("\t[8]\tPulse")
+        print("\t[9]\tHEV cycle (duration, or -1 to stop)")
+        print("\t[10]\tHEV configuration (indication, duration)")
         print("")
         print("\t[0]\tBack to bulb selection")
     else:

--- a/aiolifx/aiolifx.py
+++ b/aiolifx/aiolifx.py
@@ -4,6 +4,7 @@
 # This application is simply a bridge application for Lifx bulbs.
 #
 # Copyright (c) 2016 François Wautier
+# Copyright (c) 2022 Michael Farrell <micolous+git@gmail.com>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -1213,6 +1214,123 @@ class Light(Device):
             self.infrared_brightness = infrared_brightness
         elif resp:
             self.infrared_brightness = resp.infrared_brightness
+
+    def get_hev_cycle(self, callb):
+        """Request the state of any running HEV cycle of the device.
+
+        This method only works with LIFX Clean bulbs.
+
+        This method will do nothing unless a call back is passed to it.
+
+        :param callb: Callable to be used when the response is received.
+        :type callb: callable
+        :returns: None
+        :rtype: None
+        """
+        self.req_with_resp(GetHevCycle, StateHevCycle, callb=callb)
+
+    def set_hev_cycle(self, enable=True, duration=0, callb=None, rapid=False):
+        """Immediately starts a HEV cycle on the device.
+
+        This method only works with LIFX Clean bulbs.
+
+        This method will send a SetHevCycle message to the device, and request
+        callb be executed when an ACK is received.
+
+        :param enable: If True, start the HEV cycle, otherwise abort.
+        :type enable: bool
+        :param duration: The duration, in seconds, of the HEV cycle. If 0,
+                         use the default configuration on the bulb.
+        :type duration: int
+        :param callb: Callable to be used when the response is received.
+        :type callb: callable
+        :param rapid: Whether to ask for ack (False) or not (True). Default False
+        :type rapid: bool
+        :returns: None
+        :rtype: None
+        """
+        if rapid:
+            self.fire_and_forget(
+                SetHevCycle,
+                {"enable": int(enable), "duration": duration},
+                num_repeats=1,
+            )
+            if callb:
+                callb(self, None)
+        else:
+            self.req_with_resp(
+                SetHevCycle,
+                StateHevCycle,
+                {"enable": int(enable), "duration": duration},
+                callb=callb,
+            )
+
+    def get_hev_configuration(self, callb):
+        """Requests the default HEV configuration of the device.
+
+        This method only works with LIFX Clean bulbs.
+
+        This method will do nothing unless a call back is passed to it.
+
+        :param callb: Callable to be used when the response is received.
+        :type callb: callable
+        :returns: None
+        :rtype: None
+        """
+        self.req_with_resp(
+            GetHevCycleConfiguration, StateHevCycleConfiguration, callb=callb)
+
+    def set_hev_configuration(self, indication, duration, callb=None, rapid=False):
+        """Sets the default HEV configuration of the device.
+
+        This method only works with LIFX Clean bulbs.
+
+        This method will send a SetHevCycleConfiguration message to the device,
+        and request callb be executed when an ACK is received.
+
+        :param indication: If True, show a short flashing indication when the
+                           HEV cycle finishes.
+        :type indication: bool
+        :param duration: The duration, in seconds, of the HEV cycle.
+        :type duration: int
+        :param callb: Callable to be used when the response is received.
+        :type callb: callable
+        :param rapid: Whether to ask for ack (False) or not (True). Default False
+        :type rapid: bool
+        :returns: None
+        :rtype: None
+        """
+        if rapid:
+            self.fire_and_forget(
+                SetHevCycleConfiguration,
+                {"indication": int(indication), "duration": duration},
+                num_repeats=1,
+            )
+            if callb:
+                callb(self, None)
+        else:
+            self.req_with_resp(
+                SetHevCycleConfiguration,
+                StateHevCycleConfiguration,
+                {"indication": int(indication), "duration": duration},
+                callb=callb,
+            )
+
+    # Get last HEV cycle result
+    def get_last_hev_cycle_result(self, callb=None):
+        """Requests the result of the last HEV cycle of the device.
+
+        This method only works with LIFX Clean bulbs.
+
+        This method will do nothing unless a call back is passed to it.
+
+        :param callb: Callable to be used when the response is received.
+        :type callb: callable
+        :returns: None
+        :rtype: None
+        """
+        self.req_with_resp(
+            GetLastHevCycleResult, StateLastHevCycleResult, callb=callb)
 
     def get_accesspoint(self, callb=None):
         """Convenience method to request the access point available

--- a/aiolifx/msgtypes.py
+++ b/aiolifx/msgtypes.py
@@ -1111,6 +1111,210 @@ class LightSetInfrared(Message):
         return payload
 
 
+##### HEV (LIFX Clean) MESSAGES #####
+# https://lan.developer.lifx.com/docs/hev-light-control
+class GetHevCycle(Message):
+    def __init__(
+        self,
+        target_addr,
+        source_id,
+        seq_num,
+        payload={},
+        ack_requested=False,
+        response_requested=False,
+    ):
+        super(GetHevCycle, self).__init__(
+            MSG_IDS[GetHevCycle],
+            target_addr,
+            source_id,
+            seq_num,
+            ack_requested,
+            response_requested,
+        )
+
+
+class SetHevCycle(Message):
+    def __init__(
+        self,
+        target_addr,
+        source_id,
+        seq_num,
+        payload,
+        ack_requested=False,
+        response_requested=False,
+    ):
+        self.enable = payload["enable"]
+        self.duration = payload["duration"]
+        super(SetHevCycle, self).__init__(
+            MSG_IDS[SetHevCycle],
+            target_addr,
+            source_id,
+            seq_num,
+            ack_requested,
+            response_requested,
+        )
+
+    def get_payload(self):
+        enable = little_endian(bitstring.pack("uint:8", self.enable))
+        duration = little_endian(bitstring.pack("uint:32", self.duration))
+        payload = enable + duration
+        return payload
+
+
+class StateHevCycle(Message):
+    def __init__(
+        self,
+        target_addr,
+        source_id,
+        seq_num,
+        payload,
+        ack_requested=False,
+        response_requested=False,
+    ):
+        self.duration = payload["duration"]
+        self.remaining = payload["remaining"]
+        self.last_power = payload["last_power"]
+        super(StateHevCycle, self).__init__(
+            MSG_IDS[StateHevCycle],
+            target_addr,
+            source_id,
+            seq_num,
+            ack_requested,
+            response_requested,
+        )
+
+    def get_payload(self):
+        duration = little_endian(bitstring.pack("uint:32", self.duration))
+        remaining = little_endian(bitstring.pack("uint:32", self.remaining))
+        last_power = little_endian(bitstring.pack("uint:8", self.last_power))
+        payload = duration + remaining + last_power
+        return payload
+
+
+class GetHevCycleConfiguration(Message):
+    def __init__(
+        self,
+        target_addr,
+        source_id,
+        seq_num,
+        payload={},
+        ack_requested=False,
+        response_requested=False,
+    ):
+        super(GetHevCycleConfiguration, self).__init__(
+            MSG_IDS[GetHevCycleConfiguration],
+            target_addr,
+            source_id,
+            seq_num,
+            ack_requested,
+            response_requested,
+        )
+
+
+class SetHevCycleConfiguration(Message):
+    def __init__(
+        self,
+        target_addr,
+        source_id,
+        seq_num,
+        payload,
+        ack_requested=False,
+        response_requested=False,
+    ):
+        self.indication = payload["indication"]
+        self.duration = payload["duration"]
+        super(SetHevCycleConfiguration, self).__init__(
+            MSG_IDS[SetHevCycleConfiguration],
+            target_addr,
+            source_id,
+            seq_num,
+            ack_requested,
+            response_requested,
+        )
+
+    def get_payload(self):
+        indication = little_endian(bitstring.pack("uint:8", self.indication))
+        duration = little_endian(bitstring.pack("uint:32", self.duration))
+        payload = indication + duration
+        return payload
+
+
+class StateHevCycleConfiguration(Message):
+    def __init__(
+        self,
+        target_addr,
+        source_id,
+        seq_num,
+        payload,
+        ack_requested=False,
+        response_requested=False,
+    ):
+        self.indication = payload["indication"]
+        self.duration = payload["duration"]
+        super(StateHevCycleConfiguration, self).__init__(
+            MSG_IDS[StateHevCycleConfiguration],
+            target_addr,
+            source_id,
+            seq_num,
+            ack_requested,
+            response_requested,
+        )
+
+    def get_payload(self):
+        indication = little_endian(bitstring.pack("uint:8", self.indication))
+        duration = little_endian(bitstring.pack("uint:32", self.duration))
+        payload = indication + duration
+        return payload
+
+
+class GetLastHevCycleResult(Message):
+    def __init__(
+        self,
+        target_addr,
+        source_id,
+        seq_num,
+        payload={},
+        ack_requested=False,
+        response_requested=False,
+    ):
+        super(GetLastHevCycleResult, self).__init__(
+            MSG_IDS[GetLastHevCycleResult],
+            target_addr,
+            source_id,
+            seq_num,
+            ack_requested,
+            response_requested,
+        )
+
+
+class StateLastHevCycleResult(Message):
+    def __init__(
+        self,
+        target_addr,
+        source_id,
+        seq_num,
+        payload,
+        ack_requested=False,
+        response_requested=False,
+    ):
+        self.result = payload["result"]
+        super(StateLastHevCycleResult, self).__init__(
+            MSG_IDS[StateLastHevCycleResult],
+            target_addr,
+            source_id,
+            seq_num,
+            ack_requested,
+            response_requested,
+        )
+
+    def get_payload(self):
+        result = little_endian(bitstring.pack("uint:8", self.result))
+        return result
+
+    @property
+    def result_str(self):
+        return LAST_HEV_CYCLE_RESULT.get(self.result, 'UNKNOWN')
+
 ##### MULTIZONE MESSAGES #####
 
 
@@ -1288,6 +1492,14 @@ MSG_IDS = {
     LightGetInfrared: 120,
     LightStateInfrared: 121,
     LightSetInfrared: 122,
+    GetHevCycle: 142,
+    SetHevCycle: 143,
+    StateHevCycle: 144,
+    GetHevCycleConfiguration: 145,
+    SetHevCycleConfiguration: 146,
+    StateHevCycleConfiguration: 147,
+    GetLastHevCycleResult: 148,
+    StateLastHevCycleResult: 149,
     MultiZoneSetColorZones: 501,
     MultiZoneGetColorZones: 502,
     MultiZoneStateZone: 503,
@@ -1300,6 +1512,15 @@ STR_MAP = {65535: "On", 0: "Off", None: "Unknown"}
 
 ZONE_MAP = {0: "NO_APPLY", 1: "APPLY", 2: "APPLY_ONLY"}
 
+LAST_HEV_CYCLE_RESULT = {
+    0: "SUCCESS",
+    1: "BUSY",
+    2: "INTERRUPTED_BY_RESET",
+    3: "INTERRUPTED_BY_HOMEKIT",
+    4: "INTERRUPTED_BY_LAN",
+    5: "INTERRUPTED_BY_CLOUD",
+    255: "NONE",
+}
 
 def str_map(key):
     string_representation = "Unknown"

--- a/aiolifx/unpack.py
+++ b/aiolifx/unpack.py
@@ -324,6 +324,61 @@ def unpack_lifx_message(packed_message):
             target_addr, source_id, seq_num, payload, ack_requested, response_requested
         )
 
+    elif message_type == MSG_IDS[GetHevCycle]:  # 142
+        message = GetHevCycle(
+            target_addr, source_id, seq_num, {}, ack_requested, response_requested
+        )
+
+    elif message_type == MSG_IDS[SetHevCycle]:  # 143
+        enable, duration = struct.unpack("<BI", payload_str[:5])
+        payload = {"enable": enable == 1, "duration": duration}
+        message = SetHevCycle(
+            target_addr, source_id, seq_num, payload, ack_requested, response_requested
+        )
+
+    elif message_type == MSG_IDS[StateHevCycle]:  # 144
+        duration, remaining, last_power = struct.unpack("<IIB", payload_str[:9])
+        payload = {
+            "duration": duration,
+            "remaining": remaining,
+            "last_power": last_power == 1,
+        }
+        message = StateHevCycle(
+            target_addr, source_id, seq_num, payload, ack_requested, response_requested
+        )
+
+    elif message_type == MSG_IDS[GetHevCycleConfiguration]:  # 145
+        message = GetHevCycleConfiguration(
+            target_addr, source_id, seq_num, {}, ack_requested, response_requested
+        )
+
+    elif message_type == MSG_IDS[SetHevCycleConfiguration]:  # 146
+        indication, duration = struct.unpack("<BI", payload_str[:5])
+        payload = {"indication": indication == 1, "duration": duration}
+        message = SetHevCycleConfiguration(
+            target_addr, source_id, seq_num, payload, ack_requested, response_requested
+        )
+
+    elif message_type == MSG_IDS[StateHevCycleConfiguration]:  # 147
+        indication, duration = struct.unpack("<BI", payload_str[:5])
+        payload = {"indication": indication == 1, "duration": duration}
+        message = StateHevCycleConfiguration(
+            target_addr, source_id, seq_num, payload, ack_requested, response_requested
+        )
+
+    elif message_type == MSG_IDS[GetLastHevCycleResult]:  # 148
+        message = GetLastHevCycleResult(
+            target_addr, source_id, seq_num, {}, ack_requested, response_requested
+        )
+
+    elif message_type == MSG_IDS[StateLastHevCycleResult]:  # 149
+        result, = struct.unpack("<B", payload_str[:1])
+        payload = {"result": result}
+        message = StateLastHevCycleResult(
+            target_addr, source_id, seq_num, payload, ack_requested, response_requested
+        )
+
+
     elif message_type == MSG_IDS[MultiZoneStateZone]:  # 503
         count = struct.unpack("c", payload_str[0:1])[0]
         count = ord(count)  # 8 bit

--- a/examples/lifx-cli.py
+++ b/examples/lifx-cli.py
@@ -4,6 +4,7 @@
 # This application is an example on how to use aiolifx
 #
 # Copyright (c) 2016 François Wautier
+# Copyright (c) 2022 Michael Farrell <micolous+git@gmail.com>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -169,6 +170,63 @@ def readin():
                         print(
                             "Error: For pulse you must indicate hue (0-360), saturation (0-100) and brightness (0-100))\n"
                         )
+                elif int(lov[0]) == 9:
+                    # HEV cycle
+                    if len(lov) == 1:
+                        # Get current state
+                        print("Getting current HEV state")
+                        MyBulbs.boi.get_hev_cycle(
+                            callb=lambda _, r: print(
+                                f"\nHEV: duration={r.duration}, "
+                                f"remaining={r.remaining}, "
+                                f"last_power={r.last_power}"))
+                        MyBulbs.boi.get_last_hev_cycle_result(
+                            callb=lambda _, r: print(
+                                f"\nHEV result: {r.result_str}"))
+
+                    elif len(lov) == 2:
+                        duration = int(lov[1])
+                        enable = duration >= 0
+                        if enable:
+                            print(f"Running HEV cycle for {duration} second(s)")
+                        else:
+                            print(f"Aborting HEV cycle")
+                            duration = 0
+                        MyBulbs.boi.set_hev_cycle(
+                            enable=enable,
+                            duration=duration,
+                            callb=lambda _, r: print(
+                                f"\nHEV: duration={r.duration}, "
+                                f"remaining={r.remaining}, "
+                                f"last_power={r.last_power}"))
+                    else:
+                        print("Error: maximum 1 argument for HEV cycle")
+                    MyBulbs.boi = None
+                elif int(lov[0]) == 10:
+                    # HEV cycle configuration
+                    if len(lov) == 1:
+                        # Get current state
+                        print("Getting current HEV configuration")
+                        MyBulbs.boi.get_hev_configuration(
+                            callb=lambda _, r: print(
+                                f"\nHEV: indication={r.indication}, "
+                                f"duration={r.duration}"))
+
+                    elif len(lov) == 3:
+                        indication = bool(int(lov[1]))
+                        duration = int(lov[2])
+                        print(f"Configuring default HEV cycle with "
+                              f"{'' if indication else 'no '}indication for "
+                              f"{duration} second(s)")
+                        MyBulbs.boi.set_hev_configuration(
+                            indication=indication,
+                            duration=duration,
+                            callb=lambda _, r: print(
+                                f"\nHEV: indication={r.indication}, "
+                                f"duration={r.duration}"))
+                    else:
+                        print("Error: 0 or 2 arguments for HEV config")
+                    MyBulbs.boi = None
             # except:
             # print ("\nError: Selection must be a number.\n")
         else:
@@ -192,6 +250,8 @@ def readin():
         print("\t[6]\tWifi")
         print("\t[7]\tUptime")
         print("\t[8]\tPulse")
+        print("\t[9]\tHEV cycle (duration, or -1 to stop)")
+        print("\t[10]\tHEV configuration (indication, duration)")
         print("")
         print("\t[0]\tBack to bulb selection")
     else:
@@ -209,6 +269,10 @@ async def scan(loop, discovery):
     ips = await scanner.scan()
     print('Hit "Enter" to start')
     print("Use Ctrl-C to quit")
+    if not ips:
+        print("LIFX controller not found!")
+        return
+
     discovery.start(listen_ip=ips[0])
 
 


### PR DESCRIPTION
Reference: https://lan.developer.lifx.com/docs/hev-light-control

I'm mainly interested in using this with Home Assistant, there's some people asking about it over here: https://community.home-assistant.io/t/lifx-clean/309219

I added code for it in the example script:

```
% python examples/lifx-cli.py
Hit "Enter" to start
Use Ctrl-C to quit

Select Bulb:
(REDACTED)

Select Function for (REDACTED):
	[1]	Power (0 or 1)
	[2]	White (Brigthness Temperature)
	[3]	Colour (Hue Saturation Brightness)
	[4]	Info
	[5]	Firmware
	[6]	Wifi
	[7]	Uptime
	[8]	Pulse
	[9]	HEV cycle (duration, or -1 to stop)
	[10]	HEV configuration (indication, duration)

	[0]	Back to bulb selection

Your choice: 9
Getting current HEV state
HEV: duration=7200, remaining=0, last_power=True

HEV result: SUCCESS

## Running a HEV cycle with default duration
Your choice: 9 0
Running HEV cycle for 0 second(s)
HEV: duration=7200, remaining=0, last_power=True

## Running a cycle with a custom duration
Your choice: 9 10
Running HEV cycle for 10 second(s)
HEV: duration=10, remaining=0, last_power=True

## Aborting a running cycle
Your choice: 9 -1
Aborting HEV cycle
HEV: duration=10, remaining=0, last_power=True

## Getting the default HEV configuration
Your choice: 10
Getting current HEV configuration
HEV: indication=True, duration=7200

## Setting the default HEV configuration (no indication)
Your choice: 10 0 7199
Configuring default HEV cycle with no indication for 7199 second(s)
HEV: indication=False, duration=7199

## Setting the default HEV configuration (with indication)
Your choice: 10 1 7200
Configuring default HEV cycle with indication for 7200 second(s)
HEV: indication=True, duration=7200
```
