### PR TITLE
Add a SetReboot message type and set_reboot method

### DIFF
--- a/aiolifx/aiolifx.py
+++ b/aiolifx/aiolifx.py
@@ -707,6 +707,19 @@ class Device(aio.DatagramProtocol):
         response = self.req_with_resp(GetInfo, StateInfo, callb=callb)
         return None
 
+    def set_reboot(self):
+        """Convenience method to reboot the device
+
+        This will send a magic reboot packet to the device which has the same effect
+        as physically turning the device off and on again. Its uptime value will be
+        reset and it will be rediscovered.
+
+        There are no parameters or callbacks as the device immediately restarts with
+        any response so it just returns True to indicate the packet was sent.
+        """
+        return self.fire_and_forget(SetReboot)
+
+
     def get_version(self, callb=None):
         """Convenience method to request the version from the device
 

--- a/aiolifx/msgtypes.py
+++ b/aiolifx/msgtypes.py
@@ -669,6 +669,27 @@ class StateGroup(Message):
         return payload
 
 
+class SetReboot(Message):
+    def __init__(
+        self,
+        target_addr: str,
+        source_id: str,
+        seq_num,
+        payload,
+        ack_requested=False,
+        response_requested=False,
+    ) -> None:
+        """Initialise a SetReboot packet."""
+        super(SetReboot, self).__init__(
+            MSG_IDS[SetReboot],
+            target_addr,
+            source_id,
+            seq_num,
+            ack_requested,
+            response_requested,
+        )
+
+
 class Acknowledgement(Message):
     def __init__(
         self,
@@ -1475,6 +1496,7 @@ MSG_IDS = {
     StateVersion: 33,
     GetInfo: 34,
     StateInfo: 35,
+    SetReboot: 38,
     Acknowledgement: 45,
     GetLocation: 48,
     StateLocation: 50,

--- a/examples/lifx-cli.py
+++ b/examples/lifx-cli.py
@@ -25,6 +25,7 @@
 import sys
 import asyncio as aio
 import aiolifx as alix
+from time import sleep
 from functools import partial
 
 # Simple bulb control frpm console
@@ -237,6 +238,13 @@ def readin():
                     else:
                         print("Error: 0 or 2 arguments for HEV config")
                     MyBulbs.boi = None
+                elif int(lov[0]) == 99:
+                    # Reboot bulb
+                    print("Rebooting bulb in 3 seconds. If the bulb is on, it will flicker off and back on as it reboots.")
+                    print("Hit CTRL-C within 3 seconds to to quit without rebooting the bulb.")
+                    sleep(3)
+                    MyBulbs.boi.set_reboot()
+                    print("Bulb rebooted.")
             # except:
             # print ("\nError: Selection must be a number.\n")
         else:
@@ -262,6 +270,7 @@ def readin():
         print("\t[8]\tPulse")
         print("\t[9]\tHEV cycle (duration, or -1 to stop)")
         print("\t[10]\tHEV configuration (indication, duration)")
+        print("\t[99]\tReboot the bulb (indicated by a reboot blink)")
         print("")
         print("\t[0]\tBack to bulb selection")
     else:


### PR DESCRIPTION
This allows you to programmatically restart a device. I added an
option to `lifx-cli.py` for this as well. Check the uptime value
after the reboot to confirm it worked.

Signed-off-by: Avi Miller <me@dje.li>