### PR TITLE
Add get_multizone_effect() and set_multizone_effect()

### DIFF
--- a/aiolifx/aiolifx.py
+++ b/aiolifx/aiolifx.py
@@ -865,6 +865,7 @@ class Light(Device):
         self.hev_cycle = None
         self.hev_cycle_configuration = None
         self.last_hev_cycle_result = None
+        self.effect = {"effect": None}
 
     def get_power(self, callb=None):
         """Convenience method to request the power status from the device
@@ -1108,6 +1109,90 @@ class Light(Device):
             except:
                 # I guess this should not happen but...
                 pass
+
+    def get_multizone_effect(self, callb=None):
+        """Convenience method to get the currently running firmware effect on the device.
+
+        The value returned is the previously known state of the device. Use a callback
+        to get the current state of the device.
+
+        :param callb: Callable to be used when the response is received. If not set,
+                      self.resp_set_multizonemultizoneeffect will be used.
+        :type callb: callable
+        :returns: current effect details as a dictionary
+        :rtype: dict
+        """
+        response = self.req_with_resp(
+            MultiZoneGetMultiZoneEffect, MultiZoneStateMultiZoneEffect, callb=callb
+        )
+        return self.effect
+
+    def set_multizone_effect(
+        self, effect=0, speed=3, direction=0, callb=None, rapid=False
+    ):
+        """Convenience method to start or stop the Move firmware effect on multizone devices.
+
+        Compatible devices include LIFX Z, Lightstrip and Beam and can be identified by
+        checking if features_map[device.product]['multizone'] is True. Multizone devices
+        only have one firmware effect named "MOVE". The effect can be started and stopped
+        without the device being powered on. The effect will not be visible if the
+        device is a single uniform color.
+
+        Sending a set_power(0) to the device while the effect is running does not stop the effect.
+        Physically powering off the device will stop the effect. And the device.
+
+
+        :param effect: 0/Off, 1/Move
+        :type effect: int
+        :param speed: time in seconds for one cycle of the effect to travel the length of the device
+        :type speed: float
+        :param direction: 0/Right, 1/Left
+        :type direction: int
+        """
+
+        typ = effect
+        if type(effect) == str:
+            typ = MultiZoneEffectType[effect.upper()].value
+        elif type(effect) == int:
+            typ = effect if effect in [e.value for e in MultiZoneEffectType] else 0
+
+        speed = speed * 1000 if type(speed) == int else 3000
+
+        if type(direction) == str:
+            direction = MultiZoneDirection[direction.upper()].value
+        elif type(direction) == int:
+            direction = (
+                direction if direction in [d.value for d in MultiZoneDirection] else 0
+            )
+
+        payload = {
+            "type": typ,
+            "speed": speed,
+            "duration": 0,
+            "direction": direction,
+        }
+
+        if rapid:
+            self.fire_and_forget(MultiZoneSetMultiZoneEffect, payload)
+        else:
+            self.req_with_ack(MultiZoneSetMultiZoneEffect, payload, callb=callb)
+
+    def resp_set_multizonemultizoneeffect(self, resp):
+        """Default callback for get_multizone_effect"""
+
+        if resp:
+            self.effect = {"effect": MultiZoneEffectType(resp.effect).name.upper()}
+
+            if resp.effect != 0:
+                self.effect["speed"] = resp.speed / 1000
+                self.effect["duration"] = (
+                    0.0
+                    if resp.duration == 0
+                    else float(f"{self.effect['duration'] / 1000000000:4f}")
+                )
+                self.effect["direction"] = MultiZoneDirection(
+                    resp.direction
+                ).name.capitalize()
 
     # value should be a dictionary with the the following keys: transient, color, period, cycles, skew_ratio, waveform
     def set_waveform(self, value, callb=None, rapid=False):

--- a/aiolifx/aiolifx.py
+++ b/aiolifx/aiolifx.py
@@ -28,6 +28,7 @@ from .msgtypes import *
 from .products import *
 from .unpack import unpack_lifx_message
 from functools import partial
+from math import floor
 import time, random, datetime, socket, ifaddr
 
 # A couple of constants
@@ -1156,7 +1157,7 @@ class Light(Device):
         elif type(effect) == int:
             typ = effect if effect in [e.value for e in MultiZoneEffectType] else 0
 
-        speed = speed * 1000 if type(speed) == int else 3000
+        speed = floor(speed * 1000) if 0 < speed <= 60 else 3000
 
         if type(direction) == str:
             direction = MultiZoneDirection[direction.upper()].value

--- a/aiolifx/unpack.py
+++ b/aiolifx/unpack.py
@@ -403,6 +403,57 @@ def unpack_lifx_message(packed_message):
             target_addr, source_id, seq_num, payload, ack_requested, response_requested
         )
 
+    elif message_type == MSG_IDS[MultiZoneGetMultiZoneEffect]:  # 507
+        _, effect, _, speed, duration, _, _, _, direction, _, _ = struct.unpack(
+            "<IBHIQIIBBBB", payload_str[:31]
+        )
+        payload = {
+            "effect": effect,
+            "speed": speed,
+            "duration": duration,
+            "direction": direction,
+        }
+        message = MultiZoneGetMultiZoneEffect(
+            target_addr, source_id, seq_num, payload, ack_requested, response_requested
+        )
+
+    elif message_type == MSG_IDS[MultiZoneSetMultiZoneEffect]:  # 508
+        _, effect, _, speed, duration, _, _, _, direction, _, _ = struct.unpack(
+            "<IBHIQIIBBBB", payload_str[:31]
+        )
+        payload = {
+            "effect": effect,
+            "speed": speed,
+            "duration": duration,
+            "direction": direction,
+        }
+        message = MultiZoneSetMultiZoneEffect(
+            target_addr, source_id, seq_num, payload, ack_requested, response_requested
+        )
+
+    elif message_type == MSG_IDS[MultiZoneStateMultiZoneEffect]:  # 509
+
+        (
+            instanceid,
+            effect,
+            _,
+            speed,
+            duration,
+            _,
+            _,
+        ) = struct.unpack("<IBHIQII", payload_str[:27])
+        direction = struct.unpack("I", payload_str[31:35])[0]
+        payload = {
+            "instanceid": instanceid,
+            "effect": effect,
+            "speed": speed,
+            "duration": duration,
+            "direction": direction,
+        }
+        message = MultiZoneStateMultiZoneEffect(
+            target_addr, source_id, seq_num, payload, ack_requested, response_requested
+        )
+
     else:
         message = Message(
             message_type,

--- a/examples/lifx-cli.py
+++ b/examples/lifx-cli.py
@@ -172,72 +172,114 @@ def readin():
                             "Error: For pulse you must indicate hue (0-360), saturation (0-100) and brightness (0-100))\n"
                         )
                 elif int(lov[0]) == 9:
-                    # HEV cycle
-                    if len(lov) == 1:
-                        # Get current state
-                        print("Getting current HEV state")
-                        MyBulbs.boi.get_hev_cycle(
-                            callb=lambda _, r: print(
-                                f"\nHEV: duration={r.duration}, "
-                                f"remaining={r.remaining}, "
-                                f"last_power={r.last_power}"
+                    if alix.aiolifx.features_map[MyBulbs.boi.product]["hev"] is True:
+                        # HEV cycle
+                        if len(lov) == 1:
+                            # Get current state
+                            print("Getting current HEV state")
+                            MyBulbs.boi.get_hev_cycle(
+                                callb=lambda _, r: print(
+                                    f"\nHEV: duration={r.duration}, "
+                                    f"remaining={r.remaining}, "
+                                    f"last_power={r.last_power}"
+                                )
                             )
-                        )
-                        MyBulbs.boi.get_last_hev_cycle_result(
-                            callb=lambda _, r: print(f"\nHEV result: {r.result_str}")
-                        )
+                            MyBulbs.boi.get_last_hev_cycle_result(
+                                callb=lambda _, r: print(f"\nHEV result: {r.result_str}")
+                            )
 
-                    elif len(lov) == 2:
-                        duration = int(lov[1])
-                        enable = duration >= 0
-                        if enable:
-                            print(f"Running HEV cycle for {duration} second(s)")
+                        elif len(lov) == 2:
+                            duration = int(lov[1])
+                            enable = duration >= 0
+                            if enable:
+                                print(f"Running HEV cycle for {duration} second(s)")
+                            else:
+                                print(f"Aborting HEV cycle")
+                                duration = 0
+                            MyBulbs.boi.set_hev_cycle(
+                                enable=enable,
+                                duration=duration,
+                                callb=lambda _, r: print(
+                                    f"\nHEV: duration={r.duration}, "
+                                    f"remaining={r.remaining}, "
+                                    f"last_power={r.last_power}"
+                                ),
+                            )
                         else:
-                            print(f"Aborting HEV cycle")
-                            duration = 0
-                        MyBulbs.boi.set_hev_cycle(
-                            enable=enable,
-                            duration=duration,
+                            print("Error: maximum 1 argument for HEV cycle")
+                        MyBulbs.boi = None
+                    elif alix.aiolifx.features_map[MyBulbs.boi.product]["multizone"] is True:
+                        # Multizone firmware effect
+                        print("Getting current firmware effect state from multizone device")
+                        MyBulbs.boi.get_multizone_effect(
                             callb=lambda _, r: print(
-                                f"\nHEV: duration={r.duration}, "
-                                f"remaining={r.remaining}, "
-                                f"last_power={r.last_power}"
-                            ),
-                        )
-                    else:
-                        print("Error: maximum 1 argument for HEV cycle")
-                    MyBulbs.boi = None
-                elif int(lov[0]) == 10:
-                    # HEV cycle configuration
-                    if len(lov) == 1:
-                        # Get current state
-                        print("Getting current HEV configuration")
-                        MyBulbs.boi.get_hev_configuration(
-                            callb=lambda _, r: print(
-                                f"\nHEV: indication={r.indication}, "
-                                f"duration={r.duration}"
+                                f"\nCurrent effect={r.effect_str}"
+                                f"\nSpeed={r.speed/1000 if getattr(r, 'speed', None) is not None else 0}"
+                                f"\nDuration={r.duration/1000000000 if getattr(r, 'duration', None) is not None else 0:4f}"
+                                f"\nDirection={r.direction_str}"
                             )
                         )
+                        MyBulbs.boi = None
 
-                    elif len(lov) == 3:
-                        indication = bool(int(lov[1]))
-                        duration = int(lov[2])
-                        print(
-                            f"Configuring default HEV cycle with "
-                            f"{'' if indication else 'no '}indication for "
-                            f"{duration} second(s)"
-                        )
-                        MyBulbs.boi.set_hev_configuration(
-                            indication=indication,
-                            duration=duration,
-                            callb=lambda _, r: print(
-                                f"\nHEV: indication={r.indication}, "
-                                f"duration={r.duration}"
-                            ),
-                        )
-                    else:
-                        print("Error: 0 or 2 arguments for HEV config")
-                    MyBulbs.boi = None
+                elif int(lov[0]) == 10:
+                    if alix.aiolifx.features_map[MyBulbs.boi.product]["hev"] is True:
+                        # HEV cycle configuration
+                        if len(lov) == 1:
+                            # Get current state
+                            print("Getting current HEV configuration")
+                            MyBulbs.boi.get_hev_configuration(
+                                callb=lambda _, r: print(
+                                    f"\nHEV: indication={r.indication}, "
+                                    f"duration={r.duration}"
+                                )
+                            )
+
+                        elif len(lov) == 3:
+                            indication = bool(int(lov[1]))
+                            duration = int(lov[2])
+                            print(
+                                f"Configuring default HEV cycle with "
+                                f"{'' if indication else 'no '}indication for "
+                                f"{duration} second(s)"
+                            )
+                            MyBulbs.boi.set_hev_configuration(
+                                indication=indication,
+                                duration=duration,
+                                callb=lambda _, r: print(
+                                    f"\nHEV: indication={r.indication}, "
+                                    f"duration={r.duration}"
+                                ),
+                            )
+                        else:
+                            print("Error: 0 or 2 arguments for HEV config")
+                        MyBulbs.boi = None
+                    elif alix.aiolifx.features_map[MyBulbs.boi.product]["multizone"] is True:
+                        can_set = True
+                        if len(lov) == 3:
+                            effect = str(lov[1])
+                            direction = str(lov[2])
+
+                            if effect.lower() not in ["off", "move"]:
+                                print("Error: effect parameter must be 'off' or 'move'")
+                                can_set = False
+                            if direction.lower() not in ["left", "right"]:
+                                print("Error: direction parameter must be 'right' or 'left")
+                                can_set = False
+
+                            if can_set:
+                                e = alix.aiolifx.MultiZoneEffectType[effect.upper()].value
+                                d = alix.aiolifx.MultiZoneDirection[direction.upper()].value
+                                MyBulbs.boi.set_multizone_effect(effect=e, speed=3, direction=d)
+
+                        elif len(lov) == 2:
+                            MyBulbs.boi.set_multizone_effect(effect=0)
+
+                        else:
+                            print("Error: need to provide effect and direction parameters.")
+
+                        MyBulbs.boi = None
+
+
                 elif int(lov[0]) == 99:
                     # Reboot bulb
                     print(
@@ -265,15 +307,19 @@ def readin():
     if MyBulbs.boi:
         print("Select Function for {}:".format(MyBulbs.boi.label))
         print("\t[1]\tPower (0 or 1)")
-        print("\t[2]\tWhite (Brigthness Temperature)")
+        print("\t[2]\tWhite (Brightness Temperature)")
         print("\t[3]\tColour (Hue Saturation Brightness)")
         print("\t[4]\tInfo")
         print("\t[5]\tFirmware")
         print("\t[6]\tWifi")
         print("\t[7]\tUptime")
         print("\t[8]\tPulse")
-        print("\t[9]\tHEV cycle (duration, or -1 to stop)")
-        print("\t[10]\tHEV configuration (indication, duration)")
+        if alix.aiolifx.features_map[MyBulbs.boi.product]["hev"] is True:
+            print("\t[9]\tHEV cycle (duration, or -1 to stop)")
+            print("\t[10]\tHEV configuration (indication, duration)")
+        if alix.aiolifx.features_map[MyBulbs.boi.product]["multizone"] is True:
+            print("\t[9]\tGet firmware effect status")
+            print("\t[10]\tStart or stop firmware effect ([off/move] [right|left])")
         print("\t[99]\tReboot the bulb (indicated by a reboot blink)")
         print("")
         print("\t[0]\tBack to bulb selection")


### PR DESCRIPTION
This enables control of the Move firmware effect on linear multizone LIFX devices, including LIFX Z, Lightstrip and Beam. More detail in the `set_multizone_effect()` docstring.

The example CLI is also tweaked to only should HEV and multizone options to devices that are compatible with those options.

Signed-off-by: Avi Miller <me@dje.li>