### PR TITLE
Add support for extended_multizone messages

### DIFF
--- a/aiolifx/unpack.py
+++ b/aiolifx/unpack.py
@@ -454,6 +454,25 @@ def unpack_lifx_message(packed_message):
             target_addr, source_id, seq_num, payload, ack_requested, response_requested
         )
 
+    elif message_type == MSG_IDS[MultiZoneStateExtendedColorZones]:  # 512
+        zones_count = struct.unpack("H", payload_str[0:2])[0]
+        zone_index = struct.unpack("H", payload_str[2:4])[0]
+        colors_count = struct.unpack("B", payload_str[4:5])[0]
+        colors = []
+        for i in range(82):
+            color = struct.unpack("H" * 4, payload_str[5 + (i * 8) : 13 + (i * 8)])
+            colors.append(color)
+
+        payload = {
+            "zones_count": zones_count,
+            "zone_index": zone_index,
+            "colors_count": colors_count,
+            "colors": colors,
+        }
+        message = MultiZoneStateExtendedColorZones(
+            target_addr, source_id, seq_num, payload, ack_requested, response_requested
+        )
+
     else:
         message = Message(
             message_type,


### PR DESCRIPTION
I didn't add anything to `__main__.py` or `examples/lifx-cli.py` as there is no example for the existing `set_color_zones` method.  

However, I did create a test script that scans for multizone devices and sets a random color on each of its zones using `set_extended_color_zones` every 2 seconds which you can find here: https://gist.github.com/Djelibeybi/3d7990e861e6f1037f5101b61215db20

Just replace "INSERT MAC ADDRESS HERE" with the MAC address of a multizone device and run. Hopefully successfully. :)

Signed-off-by: Avi Miller <me@dje.li>