### PR TITLE
Add lifx switch support

### DIFF
--- a/aiolifx/aiolifx.py
+++ b/aiolifx/aiolifx.py
@@ -876,6 +876,7 @@ class Light(Device):
         self.hev_cycle_configuration = None
         self.last_hev_cycle_result = None
         self.effect = {"effect": None}
+        self.relays_power = [None, None, None, None]
 
     def get_power(self, callb=None):
         """Convenience method to request the power status from the device
@@ -1648,6 +1649,72 @@ class Light(Device):
                 )
                 self.effect["palette_count"] = resp.palette_count
                 self.effect["palette"] = resp.palette
+
+    def get_rpower(self, relay_index=None, callb=None):
+        """Method will get the power state of the relay index passed in
+
+        Will save the result into self.relays_power at the index provided
+
+        :param relay_index: The index of the relay to check power state for. If not provided, will loop through 4 relays
+        :type relay_index: int
+        :param callb: Callable to be used when the response is received.
+        :type callb: callable
+        :returns: The cached value
+        :rtype: int
+        """
+        mypartial = partial(self.resp_set_rpower)
+        if callb:
+            mycallb = lambda x, y: (mypartial(y), callb(x, y))
+        else:
+            mycallb = lambda x, y: mypartial(y)
+
+        if relay_index is not None:
+            payload = { "relay_index": relay_index }
+            response = self.req_with_resp(GetRPower, StateRPower, payload, callb=mycallb)
+        else:
+            for relay_index in range(4):
+                payload = { "relay_index": relay_index }
+                response = self.req_with_resp(GetRPower, StateRPower, payload, callb=mycallb)
+        return self.relays_power
+
+    def set_rpower(self, relay_index, is_on, callb=None, rapid=False):
+        """ Sets relay power for a given relay index
+
+            :param relay_index: The relay on the switch starting from 0.
+            :type relay_index: int
+            :param on: Whether the relay is on or not
+            :type is_on: bool
+            :param callb: Callable to be used when the response is received. If not set,
+                        self.resp_set_label will be used.
+            :type callb: callable
+            :param rapid: Whether to ask for ack (False) or not (True). Default False
+            :type rapid: bool
+            :returns: None
+            :rtype: None
+        """
+        level = 0
+        if is_on:
+            level = 65535
+
+        payload = { "relay_index": relay_index, "level": level }
+        mypartial = partial(self.resp_set_rpower, relay_index=relay_index, level=level)
+        if callb:
+            mycallb = lambda x, y: (mypartial(y), callb(x, y))
+        else:
+            mycallb = lambda x, y: mypartial(y)
+        
+        if not rapid:
+            self.req_with_resp(SetRPower, StateRPower, payload, callb=mycallb)
+        else:
+            self.fire_and_forget(SetRPower, payload)
+
+    def resp_set_rpower(self, resp, relay_index=None, level=None):
+        """Default callback for get_rpower/set_rpower"""
+        if relay_index != None and level != None:
+            self.relays_power[relay_index] = level == 65535
+        elif resp:
+            # Current models of the LIFX switch do not have dimming capability, so the two valid values are 0 for off (False) and 65535 for on (True).
+            self.relays_power[resp.relay_index] = resp.level == 65535
 
     def get_accesspoint(self, callb=None):
         """Convenience method to request the access point available

--- a/aiolifx/msgtypes.py
+++ b/aiolifx/msgtypes.py
@@ -1832,6 +1832,92 @@ class TileStateTileEffect(Message):
             )
         return payload
 
+##### RELAY (SWITCH) MESSAGES #####
+##### https://lan.developer.lifx.com/docs/the-lifx-switch #####
+
+class GetRPower(Message):
+    def __init__(
+        self,
+        target_addr,
+        source_id,
+        seq_num,
+        payload={},
+        ack_requested=False,
+        response_requested=False,
+    ):
+        self.relay_index = payload["relay_index"]
+        super(GetRPower, self).__init__(
+            MSG_IDS[GetRPower],
+            target_addr,
+            source_id,
+            seq_num,
+            ack_requested,
+            response_requested,
+        )
+
+    def get_payload(self):
+        self.payload_fields.append(("Relay Index", self.relay_index))
+        relay_index = little_endian(bitstring.pack("uint:8", self.relay_index))
+        payload = relay_index
+        return payload
+
+class SetRPower(Message):
+    def __init__(
+        self,
+        target_addr,
+        source_id,
+        seq_num,
+        payload,
+        ack_requested=False,
+        response_requested=False,
+    ):
+        self.relay_index = payload["relay_index"]
+        self.level = payload["level"]
+        super(SetRPower, self).__init__(
+            MSG_IDS[SetRPower],
+            target_addr,
+            source_id,
+            seq_num,
+            ack_requested,
+            response_requested,
+        )
+
+    def get_payload(self):
+        self.payload_fields.append(("Relay Index", self.relay_index))
+        self.payload_fields.append(("Level", self.level))
+        relay_index = little_endian(bitstring.pack("uint:8", self.relay_index))
+        level = little_endian(bitstring.pack("uint:16", self.level))
+        payload = relay_index + level
+        return payload
+
+class StateRPower(Message):
+    def __init__(
+        self,
+        target_addr,
+        source_id,
+        seq_num,
+        payload,
+        ack_requested=False,
+        response_requested=False,
+    ):
+        self.relay_index = payload["relay_index"]
+        self.level = payload["level"]
+        super(StateRPower, self).__init__(
+            MSG_IDS[StateRPower],
+            target_addr,
+            source_id,
+            seq_num,
+            ack_requested,
+            response_requested,
+        )
+
+    def get_payload(self):
+        self.payload_fields.append(("Relay Index", self.relay_index))
+        self.payload_fields.append(("Level", self.level))
+        relay_index = little_endian(bitstring.pack("uint:8", self.relay_index))
+        level = little_endian(bitstring.pack("uint:32", self.level))
+        payload = relay_index + level
+        return payload
 
 MSG_IDS = {
     GetService: 2,
@@ -1894,6 +1980,9 @@ MSG_IDS = {
     TileGetTileEffect: 718,
     TileSetTileEffect: 719,
     TileStateTileEffect: 720,
+    GetRPower: 816,
+    SetRPower: 817,
+    StateRPower: 818,
 }
 
 SERVICE_IDS = {1: "UDP", 2: "reserved", 3: "reserved", 4: "reserved"}

--- a/aiolifx/unpack.py
+++ b/aiolifx/unpack.py
@@ -496,21 +496,6 @@ def unpack_lifx_message(packed_message):
             target_addr, source_id, seq_num, payload, ack_requested, response_requested
         )
 
-
-    elif message_type == MSG_IDS[GetRPower]:  # 816
-        relay_index = struct.unpack("<BI", payload_str[:5])
-        payload = {"relay_index": relay_index}
-        message = GetRPower(
-            target_addr, source_id, seq_num, payload, ack_requested, response_requested
-        )
-
-    elif message_type == MSG_IDS[SetRPower]:  # 817
-        relay_index, level = struct.unpack("<BI", payload_str[:5])
-        payload = {"relay_index": relay_index, "level": level}
-        message = GetRPower(
-            target_addr, source_id, seq_num, payload, ack_requested, response_requested
-        )
-
     elif message_type == MSG_IDS[StateRPower]:  # 818
         relay_index = struct.unpack('B', payload_str[:1])[0]
         level = struct.unpack('>H', payload_str[1:])[0]

--- a/aiolifx/unpack.py
+++ b/aiolifx/unpack.py
@@ -496,6 +496,29 @@ def unpack_lifx_message(packed_message):
             target_addr, source_id, seq_num, payload, ack_requested, response_requested
         )
 
+
+    elif message_type == MSG_IDS[GetRPower]:  # 816
+        relay_index = struct.unpack("<BI", payload_str[:5])
+        payload = {"relay_index": relay_index}
+        message = GetRPower(
+            target_addr, source_id, seq_num, payload, ack_requested, response_requested
+        )
+
+    elif message_type == MSG_IDS[SetRPower]:  # 817
+        relay_index, level = struct.unpack("<BI", payload_str[:5])
+        payload = {"relay_index": relay_index, "level": level}
+        message = GetRPower(
+            target_addr, source_id, seq_num, payload, ack_requested, response_requested
+        )
+
+    elif message_type == MSG_IDS[StateRPower]:  # 818
+        relay_index = struct.unpack('B', payload_str[:1])[0]
+        level = struct.unpack('>H', payload_str[1:])[0]
+        payload = {"relay_index": relay_index, "level": level}
+        message = StateRPower(
+            target_addr, source_id, seq_num, payload, ack_requested, response_requested
+        )
+
     else:
         message = Message(
             message_type,

--- a/examples/lifx-cli.py
+++ b/examples/lifx-cli.py
@@ -298,6 +298,29 @@ def readin():
                             )
 
                         MyBulbs.boi = None
+                
+                elif int(lov[0]) == 11: # Relays
+                    callback = lambda x, statePower: print(f"Relay {statePower.relay_index + 1}: {'On' if statePower.level == 65535 else 'Off'}") # +1 to use 1-indexing
+                    if alix.aiolifx.features_map[MyBulbs.boi.product]["relays"] is True:
+                        if len(lov) == 3: # If user provides relay index as second param AND a third param off or on
+                            relay_index = int(lov[1]) - 1 # -1 to use 1-indexing
+                            on = [True, 1, "on"]
+                            off = [False, 0, "off"]
+                            set_power = partial(MyBulbs.boi.set_rpower, relay_index, callb=callback)
+                            if lov[2] in on:
+                                set_power(True)
+                            elif lov[2] in off:
+                                set_power(False)
+                            else:
+                                values_list = ", ".join([str(x) for lst in [on, off] for x in lst])
+                                print(f"Argument not known. Use one of these values: {values_list}")
+                        elif len(lov) == 2: # User has provided a relay index but isn't trying to set the value
+                            relay_index = int(lov[1]) - 1 # -1 to use 1-indexing
+                            MyBulbs.boi.get_rpower(relay_index, callb=callback)
+                        else: # User hasn't provided a relay index so wants all values
+                            MyBulbs.boi.get_rpower(callb=callback)
+                    else:
+                        print("This device isn't a switch and therefore doesn't have relays")
 
                 elif int(lov[0]) == 99:
                     # Reboot bulb
@@ -339,6 +362,8 @@ def readin():
         if alix.aiolifx.features_map[MyBulbs.boi.product]["multizone"] is True:
             print("\t[9]\tGet firmware effect status")
             print("\t[10]\tStart or stop firmware effect ([off/move] [right|left])")
+        if alix.aiolifx.features_map[MyBulbs.boi.product]["relays"] is True:
+            print("\t[11]\tRelays; optionally followed by relay number (beginning at 1); optionally followed by `on` or `off` to set the value")
         print("\t[99]\tReboot the bulb (indicated by a reboot blink)")
         print("")
         print("\t[0]\tBack to bulb selection")

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 # -*- coding:utf-8 -*-
 import setuptools
 
-version = "0.8.9"
+version = "0.8.10"
 
 with open("README.md", "r") as fh:
     long_description = fh.read()


### PR DESCRIPTION
Adds the three messages defined in the [LIFX Switch](https://lan.developer.lifx.com/docs/the-lifx-switch) docs:
- `GetRPower`
- `SetRPower`
- `StateRPower`

Screenshot of it working on the CLI:
![image](https://user-images.githubusercontent.com/1314053/230707955-0e8a37ec-3c6e-44fb-9ec5-e405f6dd25de.png)

CLI usage is:
`11 <relay_number> <on|off>`. If you don't specify `on/off` it just tells you the status (of either all relays, or just the one if you've specified a `relay_number`)

Solves: https://github.com/frawau/aiolifx/issues/39