### PR TITLE
Switch to using async_timeout/asyncio.timeout

### DIFF
--- a/aiolifx/__main__.py
+++ b/aiolifx/__main__.py
@@ -31,6 +31,7 @@ import argparse
 
 UDP_BROADCAST_PORT = 56700
 
+
 # Simple bulb control frpm console
 class bulbs:
     """A simple class with a register and unregister methods"""

--- a/aiolifx/message.py
+++ b/aiolifx/message.py
@@ -21,7 +21,6 @@ class Message(object):
         ack_requested=False,
         response_requested=False,
     ):
-
         # Frame
         self.frame_format = ["<H", "<H", "<L"]
         self.size = None  # 16 bits/uint16

--- a/aiolifx/msgtypes.py
+++ b/aiolifx/msgtypes.py
@@ -1832,8 +1832,10 @@ class TileStateTileEffect(Message):
             )
         return payload
 
+
 ##### RELAY (SWITCH) MESSAGES #####
 ##### https://lan.developer.lifx.com/docs/the-lifx-switch #####
+
 
 class GetRPower(Message):
     def __init__(
@@ -1860,6 +1862,7 @@ class GetRPower(Message):
         relay_index = little_endian(bitstring.pack("uint:8", self.relay_index))
         payload = relay_index
         return payload
+
 
 class SetRPower(Message):
     def __init__(
@@ -1890,6 +1893,7 @@ class SetRPower(Message):
         payload = relay_index + level
         return payload
 
+
 class StateRPower(Message):
     def __init__(
         self,
@@ -1918,6 +1922,7 @@ class StateRPower(Message):
         level = little_endian(bitstring.pack("uint:32", self.level))
         payload = relay_index + level
         return payload
+
 
 MSG_IDS = {
     GetService: 2,

--- a/aiolifx/unpack.py
+++ b/aiolifx/unpack.py
@@ -4,6 +4,7 @@
 from .msgtypes import *
 import binascii
 
+
 # Creates a LIFX Message out of packed binary data
 # If the message type is not one of the officially released ones above, it will create just a Message out of it
 # If it's not in the LIFX protocol format, uhhhhh...we'll put that on a to-do list.
@@ -432,7 +433,6 @@ def unpack_lifx_message(packed_message):
         )
 
     elif message_type == MSG_IDS[MultiZoneStateMultiZoneEffect]:  # 509
-
         (
             instanceid,
             effect,
@@ -497,8 +497,8 @@ def unpack_lifx_message(packed_message):
         )
 
     elif message_type == MSG_IDS[StateRPower]:  # 818
-        relay_index = struct.unpack('B', payload_str[:1])[0]
-        level = struct.unpack('>H', payload_str[1:])[0]
+        relay_index = struct.unpack("B", payload_str[:1])[0]
+        level = struct.unpack(">H", payload_str[1:])[0]
         payload = {"relay_index": relay_index, "level": level}
         message = StateRPower(
             target_addr, source_id, seq_num, payload, ack_requested, response_requested

--- a/examples/lifx-cli.py
+++ b/examples/lifx-cli.py
@@ -28,6 +28,7 @@ import aiolifx as alix
 from time import sleep
 from functools import partial
 
+
 # Simple bulb control frpm console
 class bulbs:
     """A simple class with a register and  unregister methods"""
@@ -298,29 +299,43 @@ def readin():
                             )
 
                         MyBulbs.boi = None
-                
-                elif int(lov[0]) == 11: # Relays
-                    callback = lambda x, statePower: print(f"Relay {statePower.relay_index + 1}: {'On' if statePower.level == 65535 else 'Off'}") # +1 to use 1-indexing
+
+                elif int(lov[0]) == 11:  # Relays
+                    callback = lambda x, statePower: print(
+                        f"Relay {statePower.relay_index + 1}: {'On' if statePower.level == 65535 else 'Off'}"
+                    )  # +1 to use 1-indexing
                     if alix.aiolifx.features_map[MyBulbs.boi.product]["relays"] is True:
-                        if len(lov) == 3: # If user provides relay index as second param AND a third param off or on
-                            relay_index = int(lov[1]) - 1 # -1 to use 1-indexing
+                        if (
+                            len(lov) == 3
+                        ):  # If user provides relay index as second param AND a third param off or on
+                            relay_index = int(lov[1]) - 1  # -1 to use 1-indexing
                             on = [True, 1, "on"]
                             off = [False, 0, "off"]
-                            set_power = partial(MyBulbs.boi.set_rpower, relay_index, callb=callback)
+                            set_power = partial(
+                                MyBulbs.boi.set_rpower, relay_index, callb=callback
+                            )
                             if lov[2] in on:
                                 set_power(True)
                             elif lov[2] in off:
                                 set_power(False)
                             else:
-                                values_list = ", ".join([str(x) for lst in [on, off] for x in lst])
-                                print(f"Argument not known. Use one of these values: {values_list}")
-                        elif len(lov) == 2: # User has provided a relay index but isn't trying to set the value
-                            relay_index = int(lov[1]) - 1 # -1 to use 1-indexing
+                                values_list = ", ".join(
+                                    [str(x) for lst in [on, off] for x in lst]
+                                )
+                                print(
+                                    f"Argument not known. Use one of these values: {values_list}"
+                                )
+                        elif (
+                            len(lov) == 2
+                        ):  # User has provided a relay index but isn't trying to set the value
+                            relay_index = int(lov[1]) - 1  # -1 to use 1-indexing
                             MyBulbs.boi.get_rpower(relay_index, callb=callback)
-                        else: # User hasn't provided a relay index so wants all values
+                        else:  # User hasn't provided a relay index so wants all values
                             MyBulbs.boi.get_rpower(callb=callback)
                     else:
-                        print("This device isn't a switch and therefore doesn't have relays")
+                        print(
+                            "This device isn't a switch and therefore doesn't have relays"
+                        )
 
                 elif int(lov[0]) == 99:
                     # Reboot bulb
@@ -363,7 +378,9 @@ def readin():
             print("\t[9]\tGet firmware effect status")
             print("\t[10]\tStart or stop firmware effect ([off/move] [right|left])")
         if alix.aiolifx.features_map[MyBulbs.boi.product]["relays"] is True:
-            print("\t[11]\tRelays; optionally followed by relay number (beginning at 1); optionally followed by `on` or `off` to set the value")
+            print(
+                "\t[11]\tRelays; optionally followed by relay number (beginning at 1); optionally followed by `on` or `off` to set the value"
+            )
         print("\t[99]\tReboot the bulb (indicated by a reboot blink)")
         print("")
         print("\t[0]\tBack to bulb selection")

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setuptools.setup(
     keywords=["lifx", "light", "automation"],
     license="MIT",
     install_requires=[
+        "async_timeout>=3.0.1",
         "bitstring",
         "ifaddr",
     ],


### PR DESCRIPTION
`asyncio.wait_for` creates another tasks which leads to some race conditions in cancelation and a performance hit

cpython 3.12 will change the underlying implementation of `asyncio.wait_for` to use `asyncio.wait` but that is still a long way off for many people:

https://github.com/python/cpython/pull/98518