### PR TITLE
Upgrade `__main__.py` CLI to be more interactive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 aiolifx.egg-info
 build
+aiolifx/__pycache__

--- a/README.md
+++ b/README.md
@@ -107,10 +107,11 @@ Other things worth noting:
       keys instead of all those parameters
 
 # Development
-To develop locally, the easiest way is to from the root directory run:
+## Running locally
+Run this command each time you make changes to the project. It enters at `__main__.py`
 
 ```bash
-pip3 install . && python3 ./examples/lifx-cli.py
+pip3 install . && aiolifx
 ```
 
 # Thanks

--- a/aiolifx/__main__.py
+++ b/aiolifx/__main__.py
@@ -22,12 +22,16 @@
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
 # WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
 # IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE
-import sys
+from enum import Enum
 import asyncio as aio
+
+import click
 import aiolifx as alix
 from functools import partial
 from time import sleep
-import argparse
+from InquirerPy import inquirer
+from InquirerPy.base.control import Choice
+from InquirerPy.validator import EmptyInputValidator
 
 UDP_BROADCAST_PORT = 56700
 
@@ -50,7 +54,7 @@ class bulbs:
         bulb.get_hostfirmware()
         self.bulbs.append(bulb)
         self.bulbs.sort(key=lambda x: x.label or x.mac_addr)
-        if opts.extra:
+        if opts["extra"]:
             bulb.register_callback(lambda y: print("Unexpected message: %s" % str(y)))
 
     def unregister(self, bulb):
@@ -62,315 +66,345 @@ class bulbs:
             idx += 1
 
 
-def readin():
-    """Reading from stdin and displaying menu"""
-    global MyBulbs
+class DeviceFeatures(Enum):
+    INFO = "Info"
+    FIRMWARE = "Firmware"
+    WIFI = "Wifi"
+    UPTIME = "Uptime"
+    POWER = "Power"
+    WHITE = "White"
+    COLOR = "Color"
+    PULSE = "Pulse"
+    HEV_CYCLE = "HEV Cycle"
+    HEV_CONFIGURATION = "HEV Configuration"
+    FIRMWARE_EFFECT = "Firmware Effect"
+    FIRMWARE_EFFECT_START_STOP = "Firmware Effect Start/Stop"
+    RELAYS = "Relays"
+    REBOOT = "Reboot"
 
-    selection = sys.stdin.readline().strip("\n")
-    MyBulbs.bulbs.sort(key=lambda x: x.label or x.mac_addr)
-    lov = [x for x in selection.split(" ") if x != ""]
-    if lov:
-        if MyBulbs.boi:
-            try:
-                if True:
-                    if int(lov[0]) == 0:
-                        MyBulbs.boi = None
-                    elif int(lov[0]) == 1:
-                        if len(lov) > 1:
-                            MyBulbs.boi.set_power(lov[1].lower() in ["1", "on", "true"])
-                            MyBulbs.boi = None
-                        else:
-                            print("Error: For power you must indicate on or off\n")
-                    elif int(lov[0]) == 2:
-                        if len(lov) > 2:
-                            try:
-                                MyBulbs.boi.set_color(
-                                    [
-                                        58275,
-                                        0,
-                                        int(round((float(lov[1]) * 65365.0) / 100.0)),
-                                        int(round(float(lov[2]))),
-                                    ]
-                                )
 
-                                MyBulbs.boi = None
-                            except:
-                                print(
-                                    "Error: For white brightness (0-100) and temperature (2500-9000) must be numbers.\n"
-                                )
-                        else:
-                            print(
-                                "Error: For white you must indicate brightness (0-100) and temperature (2500-9000)\n"
-                            )
-                    elif int(lov[0]) == 3:
-                        if len(lov) > 3:
-                            try:
-                                MyBulbs.boi.set_color(
-                                    [
-                                        int(round((float(lov[1]) * 65535.0) / 360.0)),
-                                        int(round((float(lov[2]) * 65535.0) / 100.0)),
-                                        int(round((float(lov[3]) * 65535.0) / 100.0)),
-                                        3500,
-                                    ]
-                                )
-                                MyBulbs.boi = None
-                            except:
-                                print(
-                                    "Error: For colour hue (0-360), saturation (0-100) and brightness (0-100)) must be numbers.\n"
-                                )
-                        else:
-                            print(
-                                "Error: For colour you must indicate hue (0-360), saturation (0-100) and brightness (0-100))\n"
-                            )
+def get_features(bulb):
+    base_options = [
+        DeviceFeatures.INFO,
+        DeviceFeatures.FIRMWARE,
+        DeviceFeatures.WIFI,
+        DeviceFeatures.UPTIME,
+        DeviceFeatures.REBOOT,
+    ]
+    features = []
+    if alix.aiolifx.products_dict[bulb].max_kelvin != None:
+        features.extend([DeviceFeatures.POWER, DeviceFeatures.WHITE])
+    if alix.aiolifx.products_dict[bulb].color is True:
+        features.extend([DeviceFeatures.COLOR, DeviceFeatures.PULSE])
+    if alix.aiolifx.products_dict[bulb].hev is True:
+        features.extend([DeviceFeatures.HEV_CYCLE, DeviceFeatures.HEV_CONFIGURATION])
+    if alix.aiolifx.products_dict[bulb].multizone is True:
+        features.extend(
+            [DeviceFeatures.FIRMWARE_EFFECT, DeviceFeatures.FIRMWARE_EFFECT_START_STOP]
+        )
+    if alix.aiolifx.products_dict[bulb].buttons is True:
+        features.append(DeviceFeatures.RELAYS)
+    features.extend(base_options)
+    return features
 
-                    elif int(lov[0]) == 4:
-                        print(MyBulbs.boi.device_characteristics_str("    "))
-                        print(MyBulbs.boi.device_product_str("    "))
-                        MyBulbs.boi = None
-                    elif int(lov[0]) == 5:
-                        print(MyBulbs.boi.device_firmware_str("   "))
-                        MyBulbs.boi = None
-                    elif int(lov[0]) == 6:
-                        mypartial = partial(MyBulbs.boi.device_radio_str)
-                        MyBulbs.boi.get_wifiinfo(
-                            callb=lambda x, y: print("\n" + mypartial(y))
-                        )
-                        MyBulbs.boi = None
-                    elif int(lov[0]) == 7:
-                        mypartial = partial(MyBulbs.boi.device_time_str)
-                        MyBulbs.boi.get_hostinfo(
-                            callb=lambda x, y: print("\n" + mypartial(y))
-                        )
-                        MyBulbs.boi = None
-                    elif int(lov[0]) == 8:
-                        if len(lov) > 3:
-                            try:
-                                MyBulbs.boi.set_waveform(
-                                    {
-                                        "color": [
-                                            int(
-                                                round((float(lov[1]) * 65535.0) / 360.0)
-                                            ),
-                                            int(
-                                                round((float(lov[2]) * 65535.0) / 100.0)
-                                            ),
-                                            int(
-                                                round((float(lov[3]) * 65535.0) / 100.0)
-                                            ),
-                                            3500,
-                                        ],
-                                        "transient": 1,
-                                        "period": 100,
-                                        "cycles": 30,
-                                        "skew_ratio": 0,
-                                        "waveform": 3,
-                                    }
-                                )
-                                MyBulbs.boi = None
-                            except:
-                                print(
-                                    "Error: For pulse hue (0-360), saturation (0-100) and brightness (0-100)) must be numbers.\n"
-                                )
-                        else:
-                            print(
-                                "Error: For pulse you must indicate hue (0-360), saturation (0-100) and brightness (0-100))\n"
-                            )
-                    elif int(lov[0]) == 9:
-                        if (
-                            alix.aiolifx.features_map[MyBulbs.boi.product]["hev"]
-                            is True
-                        ):
-                            # HEV cycle
-                            if len(lov) == 1:
-                                # Get current state
-                                print("Getting current HEV state")
-                                MyBulbs.boi.get_hev_cycle(
-                                    callb=lambda _, r: print(
-                                        f"\nHEV: duration={r.duration}, "
-                                        f"remaining={r.remaining}, "
-                                        f"last_power={r.last_power}"
-                                    )
-                                )
-                                MyBulbs.boi.get_last_hev_cycle_result(
-                                    callb=lambda _, r: print(
-                                        f"\nHEV result: {r.result_str}"
-                                    )
-                                )
 
-                            elif len(lov) == 2:
-                                try:
-                                    duration = int(lov[1])
-                                    enable = duration >= 0
-                                    if enable:
-                                        print(
-                                            f"Running HEV cycle for {duration} second(s)"
-                                        )
-                                    else:
-                                        print(f"Aborting HEV cycle")
-                                        duration = 0
-                                    MyBulbs.boi.set_hev_cycle(
-                                        enable=enable,
-                                        duration=duration,
-                                        callb=lambda _, r: print(
-                                            f"\nHEV: duration={r.duration}, "
-                                            f"remaining={r.remaining}, "
-                                            f"last_power={r.last_power}"
-                                        ),
-                                    )
-                                except:
-                                    print("Error: duration must be an integer")
-                            else:
-                                print("Error: maximum 1 argument for HEV cycle")
-                            MyBulbs.boi = None
-                        elif (
-                            alix.aiolifx.features_map[MyBulbs.boi.product]["multizone"]
-                            is True
-                        ):
-                            # Multizone firmware effect
-                            print(
-                                "Getting current firmware effect state from multizone device"
-                            )
-                            MyBulbs.boi.get_multizone_effect(
-                                callb=lambda _, r: print(
-                                    f"\nCurrent effect={r.effect_str}"
-                                    f"\nSpeed={r.speed/1000 if getattr(r, 'speed', None) is not None else 0}"
-                                    f"\nDuration={r.duration/1000000000 if getattr(r, 'duration', None) is not None else 0:4f}"
-                                    f"\nDirection={r.direction_str}"
-                                )
-                            )
-                            MyBulbs.boi = None
+async def get_device(devices):
+    device_choices = [
+        Choice("back", name="❌ Quit"),
+        *[Choice(device.mac_addr, name=device.label) for device in devices],
+    ]
+    device_mac_addr = await inquirer.fuzzy(
+        message="Select a device", choices=device_choices
+    ).execute_async()
+    device = next(
+        (device for device in devices if device.mac_addr == device_mac_addr), None
+    )
+    return device
 
-                    elif int(lov[0]) == 10:
-                        if (
-                            alix.aiolifx.features_map[MyBulbs.boi.product]["hev"]
-                            is True
-                        ):
-                            # HEV cycle configuration
-                            if len(lov) == 1:
-                                # Get current state
-                                print("Getting current HEV configuration")
-                                MyBulbs.boi.get_hev_configuration(
-                                    callb=lambda _, r: print(
-                                        f"\nHEV: indication={r.indication}, "
-                                        f"duration={r.duration}"
-                                    )
-                                )
 
-                            elif len(lov) == 3:
-                                try:
-                                    indication = bool(int(lov[1]))
-                                    duration = int(lov[2])
-                                    print(
-                                        f"Configuring default HEV cycle with "
-                                        f"{'' if indication else 'no '}indication for "
-                                        f"{duration} second(s)"
-                                    )
-                                    MyBulbs.boi.set_hev_configuration(
-                                        indication=indication,
-                                        duration=duration,
-                                        callb=lambda _, r: print(
-                                            f"\nHEV: indication={r.indication}, "
-                                            f"duration={r.duration}"
-                                        ),
-                                    )
-                                except:
-                                    print(
-                                        "Error: both indication and duration must be integer."
-                                    )
-                            else:
-                                print("Error: 0 or 2 arguments for HEV config")
-                            MyBulbs.boi = None
-                        elif (
-                            alix.aiolifx.features_map[MyBulbs.boi.product]["multizone"]
-                            is True
-                        ):
-                            can_set = True
-                            if len(lov) == 3:
-                                effect = str(lov[1])
-                                direction = str(lov[2])
+async def get_feature(device):
+    features = get_features(device.product)
+    features_choices = [
+        (Choice("back", name="❌ Go back to device selection")),
+        *[Choice(feature, name=feature.value) for feature in features],
+    ]
+    option = await inquirer.fuzzy(
+        message="Select an option", choices=features_choices
+    ).execute_async()
+    if option == "back":
+        return None
+    return option
 
-                                if effect.lower() not in ["off", "move"]:
-                                    print(
-                                        "Error: effect parameter must be 'off' or 'move'"
-                                    )
-                                    can_set = False
-                                if direction.lower() not in ["left", "right"]:
-                                    print(
-                                        "Error: direction parameter must be 'right' or 'left"
-                                    )
-                                    can_set = False
 
-                                if can_set:
-                                    e = alix.aiolifx.MultiZoneEffectType[
-                                        effect.upper()
-                                    ].value
-                                    d = alix.aiolifx.MultiZoneDirection[
-                                        direction.upper()
-                                    ].value
-                                    MyBulbs.boi.set_multizone_effect(
-                                        effect=e, speed=3, direction=d
-                                    )
+async def readin():
+    while True:
+        device = await get_device(MyBulbs.bulbs)
+        if device is None:
+            break
+        feature = await get_feature(device)
+        if feature is None:  # if going back
+            continue
+        if feature == DeviceFeatures.POWER:
+            power_level = await inquirer.select(
+                message="Select a power level", choices=["On", "Off"]
+            ).execute_async()
+            device.set_power(power_level.lower())
+        elif feature == DeviceFeatures.WHITE:
+            brightness = await inquirer.number(
+                "Brightness (0 - 100)",
+                replace_mode=True,
+                min_allowed=0,
+                max_allowed=100,
+                validate=EmptyInputValidator(),
+            ).execute_async()
+            while True:
+                kelvin = await inquirer.number(
+                    "Kelvin (2500 - 9000)",
+                    min_allowed=0,
+                    max_allowed=9000,
+                    validate=EmptyInputValidator(),
+                ).execute_async()
+                if int(kelvin) < 2500:
+                    print("Kelvin must be greater than 2500")
+                    continue
+                break
+            device.set_color(
+                [
+                    58275,
+                    0,
+                    int(round((float(brightness) * 65365.0) / 100.0)),
+                    float(kelvin),
+                ]
+            )
+        elif feature == DeviceFeatures.COLOR:
+            hue = await inquirer.number(
+                "Hue (0 - 360)",
+                replace_mode=True,
+                min_allowed=0,
+                max_allowed=360,
+                validate=EmptyInputValidator(),
+            ).execute_async()
+            saturation = await inquirer.number(
+                "Saturation (0 - 100)",
+                replace_mode=True,
+                min_allowed=0,
+                max_allowed=100,
+                validate=EmptyInputValidator(),
+            ).execute_async()
+            brightness = await inquirer.number(
+                "Brightness (0 - 100)",
+                replace_mode=True,
+                min_allowed=0,
+                max_allowed=100,
+                validate=EmptyInputValidator(),
+            ).execute_async()
+            device.set_color(
+                [
+                    int(round((float(hue) * 65535.0) / 360.0)),
+                    int(round((float(saturation) * 65535.0) / 100.0)),
+                    int(round((float(brightness) * 65535.0) / 100.0)),
+                    3500,
+                ]
+            )
+            device = None
 
-                            elif len(lov) == 2:
-                                MyBulbs.boi.set_multizone_effect(effect=0)
+        elif feature == DeviceFeatures.INFO:
+            print(device.device_characteristics_str("    "))
+            print(device.device_product_str("    "))
+            device = None
+        elif feature == DeviceFeatures.FIRMWARE:
+            print(device.device_firmware_str("   "))
+            device = None
+        elif feature == DeviceFeatures.WIFI:
+            mypartial = partial(device.device_radio_str)
+            device.get_wifiinfo(callb=lambda x, y: print("\n" + mypartial(y)))
+            device = None
+        elif feature == DeviceFeatures.UPTIME:
+            mypartial = partial(device.device_time_str)
+            device.get_hostinfo(callb=lambda x, y: print("\n" + mypartial(y)))
+            device = None
+        elif feature == DeviceFeatures.PULSE:
+            hue = await inquirer.number(
+                "Hue (0 - 360)",
+                replace_mode=True,
+                min_allowed=0,
+                max_allowed=360,
+                validate=EmptyInputValidator(),
+            ).execute_async()
+            saturation = await inquirer.number(
+                "Saturation (0 - 100)",
+                replace_mode=True,
+                min_allowed=0,
+                max_allowed=100,
+                validate=EmptyInputValidator(),
+            ).execute_async()
+            brightness = await inquirer.number(
+                "Brightness (0 - 100)",
+                replace_mode=True,
+                min_allowed=0,
+                max_allowed=100,
+                validate=EmptyInputValidator(),
+            ).execute_async()
+            device.set_waveform(
+                {
+                    "color": [
+                        int(round((float(hue) * 65535.0) / 360.0)),
+                        int(round((float(saturation) * 65535.0) / 100.0)),
+                        int(round((float(brightness) * 65535.0) / 100.0)),
+                        3500,
+                    ],
+                    "transient": 1,
+                    "period": 100,
+                    "cycles": 30,
+                    "skew_ratio": 0,
+                    "waveform": 3,
+                }
+            )
+            device = None
+        elif feature == DeviceFeatures.HEV_CYCLE:
+            device.get_hev_cycle(
+                callb=lambda _, r: print(
+                    f"\nHEV: duration={r.duration}, "
+                    f"remaining={r.remaining}, "
+                    f"last_power={r.last_power}"
+                )
+            )
+            device.get_last_hev_cycle_result(
+                callb=lambda _, r: print(f"\nHEV result: {r.result_str}")
+            )
+            set_duration = await inquirer.confirm(
+                message="Set duration?", default=False
+            ).execute_async()
+            if set_duration:
+                duration = await inquirer.number(
+                    "Duration (seconds)",
+                    replace_mode=True,
+                    min_allowed=0,
+                    validate=EmptyInputValidator(),
+                ).execute_async()
+                enable = duration >= 0
+                if enable:
+                    print(f"Running HEV cycle for {duration} second(s)")
+                else:
+                    print(f"Aborting HEV cycle")
+                    duration = 0
+                device.set_hev_cycle(
+                    enable=enable,
+                    duration=duration,
+                    callb=lambda _, r: print(
+                        f"\nHEV: duration={r.duration}, "
+                        f"remaining={r.remaining}, "
+                        f"last_power={r.last_power}"
+                    ),
+                )
 
-                            else:
-                                print(
-                                    "Error: need to provide effect and direction parameters."
-                                )
+            device = None
+        elif feature == DeviceFeatures.FIRMWARE_EFFECT:
+            print("Getting current firmware effect state from multizone device")
+            device.get_multizone_effect(
+                callb=lambda _, r: print(
+                    f"\nCurrent effect={r.effect_str}"
+                    f"\nSpeed={r.speed/1000 if getattr(r, 'speed', None) is not None else 0}"
+                    f"\nDuration={r.duration/1000000000 if getattr(r, 'duration', None) is not None else 0:4f}"
+                    f"\nDirection={r.direction_str}"
+                )
+            )
+            device = None
+        elif feature == DeviceFeatures.FIRMWARE_EFFECT_START_STOP:
+            print("HELLO")
+            effect = await inquirer.fuzzy(
+                message="Effect",
+                choices=["Off", "Move"],
+            ).execute_async()
 
-                            MyBulbs.boi = None
-                    elif int(lov[0]) == 99:
-                        # Reboot bulb
-                        print(
-                            "Rebooting bulb in 3 seconds. If the bulb is on, it will flicker off and back on as it reboots."
-                        )
-                        print(
-                            "Hit CTRL-C within 3 seconds to to quit without rebooting the bulb."
-                        )
-                        sleep(3)
-                        MyBulbs.boi.set_reboot()
-                        print("Bulb rebooted.")
-            except:
-                print("\nError: Selection must be a number.\n")
-        else:
-            try:
-                if int(lov[0]) > 0:
-                    if int(lov[0]) <= len(MyBulbs.bulbs):
-                        MyBulbs.boi = MyBulbs.bulbs[int(lov[0]) - 1]
-                    else:
-                        print("\nError: Not a valid selection.\n")
+            if effect.lower() == "off":
+                device.set_multizone_effect(effect=0)
+            else:
+                direction = await inquirer.fuzzy(
+                    message="Direction",
+                    choices=["Left", "Right"],
+                ).execute_async()
 
-            except:
-                print("\nError: Selection must be a number.\n")
+                e = alix.aiolifx.MultiZoneEffectType[effect.upper()].value
+                d = alix.aiolifx.MultiZoneDirection[direction.upper()].value
+                device.set_multizone_effect(effect=e, speed=3, direction=d)
+            device = None
+        elif feature == DeviceFeatures.HEV_CONFIGURATION:
+            # Get current state
+            print("Getting current HEV configuration")
+            device.get_hev_configuration(
+                callb=lambda _, r: print(
+                    f"\nHEV: indication={r.indication}, " f"duration={r.duration}"
+                )
+            )
 
-    if MyBulbs.boi:
-        print("Select Function for {}:".format(MyBulbs.boi.label))
-        print("\t[1]\tPower (0 or 1)")
-        print("\t[2]\tWhite (Brigthness Temperature)")
-        print("\t[3]\tColour (Hue Saturation Brightness)")
-        print("\t[4]\tInfo")
-        print("\t[5]\tFirmware")
-        print("\t[6]\tWifi")
-        print("\t[7]\tUptime")
-        print("\t[8]\tPulse")
-        if alix.aiolifx.features_map[MyBulbs.boi.product]["hev"] is True:
-            print("\t[9]\tHEV cycle (Nothing for query, duration or -1 to stop)")
-            print("\t[10]\tHEV configuration (Nothing for query, indication duration)")
-        if alix.aiolifx.features_map[MyBulbs.boi.product]["multizone"] is True:
-            print("\t[9]\tGet firmware effect status")
-            print("\t[10]\tStart or stop firmware effect ([off/move] [right|left])")
-        print("\t[99]\tReboot the bulb (indicated by a reboot blink)")
-        print("")
-        print("\t[0]\tBack to bulb selection")
-    else:
-        idx = 1
-        print("Select Bulb:")
-        for x in MyBulbs.bulbs:
-            print("\t[{}]\t{}".format(idx, x.label or x.mac_addr))
-            idx += 1
-    print("")
-    print("Your choice: ", end="", flush=True)
+            set_hev_configuration = await inquirer.confirm(
+                message="Set HEV configuration?", default=False
+            ).execute_async()
+            if set_hev_configuration:
+                indication = await inquirer.confirm(
+                    message="Indication?", default=False
+                ).execute_async()
+                duration = await inquirer.number(
+                    "Duration (seconds)",
+                    replace_mode=True,
+                    min_allowed=0,
+                    validate=EmptyInputValidator(),
+                ).execute_async()
+                print(
+                    f"Configuring default HEV cycle with "
+                    f"{'' if indication else 'no '}indication for "
+                    f"{duration} second(s)"
+                )
+                device.set_hev_configuration(
+                    indication=indication,
+                    duration=duration,
+                    callb=lambda _, r: print(
+                        f"\nHEV: indication={r.indication}, " f"duration={r.duration}"
+                    ),
+                )
+            device = None
+        elif feature == DeviceFeatures.REBOOT:
+            # Reboot bulb
+            print(
+                "Rebooting bulb in 3 seconds. If the bulb is on, it will flicker off and back on as it reboots."
+            )
+            print("Hit CTRL-C within 3 seconds to to quit without rebooting the bulb.")
+            sleep(3)
+            device.set_reboot()
+            print("Bulb rebooted.")
+            feature = None
+        elif feature == DeviceFeatures.RELAYS:
+            callback = lambda x, statePower: print(
+                # +1 to use 1-indexing
+                f"\nRelay {statePower.relay_index + 1}: {'On' if statePower.level == 65535 else 'Off'}"
+            )
+            device.get_rpower(callb=callback)
+            await aio.sleep(
+                0.5
+            )  # to wait for the callback to be called. TODO: use await
+            should_set_relay_state = await inquirer.confirm(
+                message="Set relay state?", default=False
+            ).execute_async()
+            if should_set_relay_state:
+                relay_index = await inquirer.number(
+                    "Relay index",
+                    replace_mode=True,
+                    min_allowed=1,
+                    max_allowed=4,
+                    validate=EmptyInputValidator(),
+                ).execute_async()
+                relay_index = int(relay_index) - 1  # Convert to 0-indexing
+                relay_state = await inquirer.select(
+                    "Relay state", choices=["On", "Off"]
+                ).execute_async()
+                set_rpower = partial(device.set_rpower, relay_index, callb=callback)
+                set_rpower(relay_state.lower() == "on")
+                await aio.sleep(
+                    0.5
+                )  # to wait for the callback to be called. TODO: use await
+            feature = None
+    return
 
 
 async def amain():
@@ -383,46 +417,36 @@ async def amain():
     loop = aio.get_event_loop()
     discovery = alix.LifxDiscovery(loop, MyBulbs)
     try:
-        loop.add_reader(sys.stdin, readin)
         discovery.start()
-        print('Hit "Enter" to start')
+        print("Starting")
+        # Wait to discover bulbs
+        await aio.sleep(1)
         print("Use Ctrl-C to quit")
-        await aio.Event().wait()
+        await readin()
     finally:
         discovery.cleanup()
-        loop.remove_reader(sys.stdin)
 
 
-def main():
+@click.command(help="Track and interact with Lifx light bulbs.")
+@click.option(
+    "-6",
+    "--ipv6prefix",
+    default=None,
+    help="Connect to Lifx using IPv6 with given /64 prefix (Do not end with colon unless you have less than 64bits).",
+)
+@click.option(
+    "-x",
+    "--extra",
+    is_flag=True,
+    default=False,
+    help="Print unexpected messages.",
+)
+def cli(ipv6prefix, extra):
     global opts
-
-    parser = argparse.ArgumentParser(
-        description="Track and interact with Lifx light bulbs."
-    )
-    parser.add_argument(
-        "-6",
-        "--ipv6prefix",
-        default=None,
-        help="Connect to Lifx using IPv6 with given /64 prefix (Do not end with colon unless you have less than 64bits).",
-    )
-    parser.add_argument(
-        "-x",
-        "--extra",
-        action="store_true",
-        default=False,
-        help="Print unexpected messages.",
-    )
-    try:
-        opts = parser.parse_args()
-    except Exception as e:
-        parser.error("Error: " + str(e))
+    opts = {"ipv6prefix": ipv6prefix, "extra": extra}
     try:
         aio.run(amain())
     except KeyboardInterrupt:
         print("\nExiting at user's request.")
     except Exception as e:
         print(f"Error: {e}")
-
-
-if __name__ == "__main__":
-    main()

--- a/aiolifx/__main__.py
+++ b/aiolifx/__main__.py
@@ -110,8 +110,8 @@ def get_features(bulb):
 
 async def get_device(devices):
     device_choices = [
-        Choice("back", name="❌ Quit"),
         *[Choice(device.mac_addr, name=device.label) for device in devices],
+        Choice("back", name="❌ Quit")
     ]
     device_mac_addr = await inquirer.fuzzy(
         message="Select a device", choices=device_choices
@@ -125,8 +125,8 @@ async def get_device(devices):
 async def get_feature(device):
     features = get_features(device.product)
     features_choices = [
-        (Choice("back", name="❌ Go back to device selection")),
         *[Choice(feature, name=feature.value) for feature in features],
+        (Choice("back", name="❌ Go back to device selection")),
     ]
     option = await inquirer.fuzzy(
         message="Select an option", choices=features_choices
@@ -422,6 +422,7 @@ async def amain():
         # Wait to discover bulbs
         await aio.sleep(1)
         print("Use Ctrl-C to quit")
+        print("Start typing or use arrow keys to navigate, and enter to select.")
         await readin()
     finally:
         discovery.cleanup()
@@ -450,3 +451,6 @@ def cli(ipv6prefix, extra):
         print("\nExiting at user's request.")
     except Exception as e:
         print(f"Error: {e}")
+
+if __name__ == "__main__":
+    cli()

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 # -*- coding:utf-8 -*-
 import setuptools
 
-version = "0.8.10"
+version = "0.9.0"
 
 with open("README.md", "r") as fh:
     long_description = fh.read()

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,8 @@ setuptools.setup(
         "async_timeout>=3.0.1",
         "bitstring",
         "ifaddr",
+        'click>=8.1.0,<8.2.0',
+        'InquirerPy>=0.3.0,<0.4.0'
     ],
     # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
     classifiers=[
@@ -32,7 +34,7 @@ setuptools.setup(
         # that you indicate whether you support Python 2, Python 3 or both.
         "Programming Language :: Python :: 3",
     ],
-    entry_points={"console_scripts": ["aiolifx=aiolifx.__main__:main"]},
+    entry_points={"console_scripts": ["aiolifx = aiolifx.__main__:cli"]},
     python_requires=">=3.4",
     zip_safe=False,
 )


### PR DESCRIPTION
I'd like to update the CLI to be more user-friendly and interactive. I think originally the CLI was good for testing and debugging when there weren't too many LIFX products, but given there are now quite a few I thought a few areas could use improvements:
- Code is a bit hard to read when we have branching options to support different lifx products/features. E.g. options 9 and 10 were either `hev` or multizone effects
- When setting values, the user needs to know **what** to input, and in what order to put arguments. E.g. for `set_color` they need to know `hue` is first, and accepts 0 through 360; `saturation` is next and accepts 0 through 100 etc.
- When unpacking user inputs in the code, we need to remember that `lov[1]` is `hue`, `lov[2]` is `saturation` etc.
- We also need to validate and error if the numbers aren't numbers or are out of range

Particularly given the changes in:
- https://github.com/frawau/aiolifx/pull/75
- https://github.com/frawau/aiolifx/pull/67
we are now supporting some really long input arguments. One example is for setting button configs: `<haptic_duration_ms> <backlight_on_color_hue> (0-360) <backlight_on_color_saturation> (0-100) <backlight_on_color_brightness> (0-100) <backlight_on_color_kelvin> (2500-9000) <backlight_off_color_hue> (0-360) <backlight_off_color_saturation> (0-100) <backlight_off_color_brightness> (0-100) <backlight_off_color_kelvin> (2500-9000)`. This doesn't even mention that if you set a `hue` the `kelvin` is ignored.

So I had a look around at a few libraries for creating an CLI which can guide the user, while still being quick to repeat the same command over and over (e.g. if you're testing like us).

Originally I looked into both `argtypes` and `click` and settled on `click` for the initial entry point and its built in `--help` command.

We need a `choice` method, which lets users pick from a number of options. Both `argtypes` and `click` support a `choice` type syntax, but I wasn't a fan as you'd need to create your own numbering, and then parse the number to get the equivalent value.

Instead I settled on [InquirerPy](https://inquirerpy.readthedocs.io/en/latest/index.html) (PyInquirer is a dead project with breaking bugs). This has a number of highly interactive CLI methods which I think dramatically reduces the complexity for a user of the CLI. Example video:

https://user-images.githubusercontent.com/1314053/232798796-f4afc830-532e-49a3-bf39-022de7f1b57d.mov

This gives us a few options to present `choices` in different ways, depending on whether its a long list, a shorter list, yes or no or a number input. We can ask a few questions in a row instead of needing the user to remember a long series of numbers for a `set` command. It restricts the choices of the user to ones we support, meaning we don't need to add our own validation to every input. I'm also putting each value into its own variable so the code should be easier to read.

I also removed the initial need to hit `Enter` to start, replacing with a 1 second timeout.

Given all of these changes, I've updated the minor version to `0.9.0` as it might be a breaking change to someone who uses the CLI.

----

Let me know what you think. I had to add a few `aio.sleep()` to make the console output messages come in the right order given the callbacks (you can see the issue in the video above when I select `uptime`). I guess we need to change the methods in `aiolifx.py` to be awaitable, but I'm not very familiar with async in Python.
