### PR TITLE
Replace expensive dir call with getattr

### DIFF
--- a/aiolifx/aiolifx.py
+++ b/aiolifx/aiolifx.py
@@ -215,10 +215,9 @@ class Device(aio.DatagramProtocol):
                             "resp_set_"
                             + response.__class__.__name__.replace("State", "").lower()
                         )
-                        if setmethod in dir(self) and callable(
-                            getattr(self, setmethod)
-                        ):
-                            getattr(self, setmethod)(response)
+                        method = getattr(self, setmethod, None)
+                        if method:
+                            method(response)
                     if callb:
                         callb(self, response)
                     myevent.set()


### PR DESCRIPTION
dir has to enumerate the entire object where
as getattr only does a lookup.

Noticed this in a profile provided by a user

tested with a lifx beam

with dir
![dir](https://github.com/frawau/aiolifx/assets/663432/52c23e2d-56bf-4107-b4b1-f19b7e3cff82)

without dir
![no_dir](https://github.com/frawau/aiolifx/assets/663432/08ee4ace-4dc6-4994-8ad2-c9d8859d0d50)

