### PR TITLE
Support IPv6 (Thread) devices in unicast connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,15 @@ Other things worth noting:
 
     - You can select to used IPv6 connection to the bulbs by passing an
       IPv6 prefix to LifxDiscovery. It's only been tried with /64 prefix.
-      If you want to use a /48 prefix, add ":" (colon) at the end of the
-      prefix and pray. (This means 2 colons at the end!)
+      Shorter prefixes (e.g. /48) are zero-filled; trailing colons on the
+      prefix are optional. This derives an EUI-64 address from the MAC of
+      a device discovered over IPv4 broadcast, so it cannot find
+      Thread-connected devices
+
+    - Devices that only have an IPv6 address (e.g. Thread devices reached
+      through a border router) can be used by passing their IPv6 address
+      directly to LIFXConnection (or Light), for instance an address
+      learned from an mDNS/zeroconf announcement of the _lifx._udp service
 
     - I only have Original 1000, so I could not test with other types
       of bulbs
@@ -113,6 +120,15 @@ Run this command each time you make changes to the project. It enters at `__main
 ```bash
 pip3 install . && aiolifx
 ```
+
+## Running the tests
+
+```bash
+pip3 install .[test] && pytest
+```
+
+Tests against real devices are opt-in; see `tests/test_live.py` for the
+environment variables that enable them.
 
 # Thanks
 

--- a/aiolifx/__main__.py
+++ b/aiolifx/__main__.py
@@ -626,7 +626,7 @@ async def amain():
     "-6",
     "--ipv6prefix",
     default=None,
-    help="Connect to Lifx using IPv6 with given /64 prefix (Do not end with colon unless you have less than 64bits).",
+    help="Connect to Lifx using IPv6 with given /64 prefix (trailing colons optional; shorter prefixes are zero-filled).",
 )
 @click.option(
     "-x",

--- a/aiolifx/aiolifx.py
+++ b/aiolifx/aiolifx.py
@@ -25,6 +25,7 @@
 # IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE
 import asyncio as aio
 import datetime
+import ipaddress
 import logging
 import random
 import socket
@@ -94,7 +95,43 @@ def mac_to_ipv6_linklocal(mac, prefix="fe80::"):
     high1 = mac_value >> 24 & 0xFF
     low1 = mac_value >> 16 & 0xFF
     low2 = mac_value & 0xFFFF
-    return prefix + ":{:04x}:{:02x}ff:fe{:02x}:{:04x}".format(high2, high1, low1, low2)
+    suffix = "{:04x}:{:02x}ff:fe{:02x}:{:04x}".format(high2, high1, low1, low2)
+    # Join so that every conventional prefix form yields a valid address:
+    # a full /64 prefix ("fd00:1:2:3", "fd00:1:2:3:" or "fe80::") is joined
+    # with ":", while shorter prefixes ("fe80", "fd00:1:2:") are zero-filled
+    # with "::". The default "fe80::" used to produce an invalid triple-colon
+    # address here.
+    prefix = prefix.rstrip(":")
+    if "::" in prefix or prefix.count(":") == 3:
+        separator = ":"
+    else:
+        separator = "::"
+    return prefix + separator + suffix
+
+
+def address_family(ip_addr):
+    """Return the socket address family for the given IP address string.
+
+    IPv4 and IPv6 literals map to their respective families (e.g. Thread
+    devices reachable via IPv6 through a border router), so the socket
+    family deterministically matches the target. Anything that is not an
+    IP literal (e.g. a hostname) maps to AF_UNSPEC so that getaddrinfo
+    remains free to pick the family, as it did before this helper existed.
+
+        :param ip_addr: the IP address of the device (either IPv4 or IPv6)
+        :type ip_addr: str
+        :returns: socket.AF_INET or socket.AF_INET6 for IP literals,
+            socket.AF_UNSPEC otherwise
+        :rtype: socket.AddressFamily
+
+    """
+    try:
+        # Scoped link-local literals ("fe80::1%en0") carry a zone id that
+        # ipaddress does not parse but getaddrinfo handles fine.
+        version = ipaddress.ip_address(ip_addr.split("%")[0]).version
+    except ValueError:
+        return socket.AF_UNSPEC
+    return socket.AF_INET6 if version == 6 else socket.AF_INET
 
 
 def nanosec_to_hours(ns):
@@ -2318,8 +2355,12 @@ class LifxDiscovery(aio.DatagramProtocol):
         :type parent: object
         :param loop: The asyncio loop being used
         :type loop: asyncio.AbstractEventLoop
-        :param: ipv6prefix: ipv6 network prefix to use
-        :type mipv6prefix: string
+        :param ipv6prefix: ipv6 network prefix to use. This derives an EUI-64
+            address from the MAC of a device discovered over IPv4 broadcast; it
+            cannot find Thread devices, whose addresses are not EUI-64 derived
+            and which never answer IPv4 broadcast. Connect to those directly by
+            their IPv6 address (e.g. from mDNS/zeroconf) instead.
+        :type ipv6prefix: string
         :param discovery_interval: How often, in seconds, to broadcast a discovery messages
         :type discovery_interval: int
         :param discovery_step: How often, in seconds, will the discovery process check if it is time to broadcast
@@ -2398,11 +2439,10 @@ class LifxDiscovery(aio.DatagramProtocol):
             return
 
         if self.ipv6prefix:
-            family = socket.AF_INET6
             remote_ip = mac_to_ipv6_linklocal(mac_addr, self.ipv6prefix)
         else:
-            family = socket.AF_INET
             remote_ip = response.ip_addr
+        family = address_family(remote_ip)
 
         if mac_addr in self.lights:
             # rediscovered

--- a/aiolifx/connection.py
+++ b/aiolifx/connection.py
@@ -23,6 +23,12 @@ class LIFXConnection:
         )
 
     def async_stop(self):
-        """Close the transport."""
-        assert self.transport is not None
+        """Close the transport, if any.
+
+        Safe to call before setup, after a failed setup, or repeatedly,
+        so callers can always clean up without masking a setup error.
+        """
+        if self.transport is None:
+            return
         self.transport.close()
+        self.transport = None

--- a/aiolifx/connection.py
+++ b/aiolifx/connection.py
@@ -1,6 +1,6 @@
 import asyncio
 
-from .aiolifx import UDP_BROADCAST_PORT, Light
+from .aiolifx import UDP_BROADCAST_PORT, Light, address_family
 
 
 class LIFXConnection:
@@ -18,6 +18,7 @@ class LIFXConnection:
         loop = asyncio.get_running_loop()
         self.transport, self.device = await loop.create_datagram_endpoint(
             lambda: Light(loop, self.mac, self.host),
+            family=address_family(self.host),
             remote_addr=(self.host, UDP_BROADCAST_PORT),
         )
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,7 @@
 [metadata]
 description_file = README.md
+
+[tool:pytest]
+asyncio_mode = auto
+asyncio_default_fixture_loop_scope = function
+testpaths = tests

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,12 @@ setuptools.setup(
         "click>=8.1.0,<8.2.0",
         "InquirerPy>=0.3.0,<0.4.0",
     ],
+    extras_require={
+        "test": [
+            "pytest",
+            "pytest-asyncio",
+        ],
+    },
     # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
     classifiers=[
         # Pick your license as you wish (should match "license" above)

--- a/tests/test_address_family.py
+++ b/tests/test_address_family.py
@@ -1,0 +1,82 @@
+"""Tests for address family selection and IPv6 address helpers."""
+
+import socket
+
+from aiolifx.aiolifx import address_family, mac_to_ipv6_linklocal
+
+
+class TestAddressFamily:
+    def test_ipv4_address(self):
+        assert address_family("192.168.1.10") == socket.AF_INET
+
+    def test_ipv4_loopback(self):
+        assert address_family("127.0.0.1") == socket.AF_INET
+
+    def test_ipv6_ula(self):
+        # Thread devices are typically reachable at a ULA published
+        # by the border router (OMR prefix).
+        assert address_family("fd12:3456:789a:1:2:3:4:5") == socket.AF_INET6
+
+    def test_ipv6_gua(self):
+        assert address_family("2001:db8::1") == socket.AF_INET6
+
+    def test_ipv6_loopback(self):
+        assert address_family("::1") == socket.AF_INET6
+
+    def test_ipv6_link_local_with_scope(self):
+        assert address_family("fe80::d273:d5ff:fe01:0203%en0") == socket.AF_INET6
+
+    def test_hostname_is_unspecified(self):
+        # Hostnames must stay AF_UNSPEC so getaddrinfo can still pick
+        # the family (e.g. a name that only resolves to an AAAA record).
+        assert address_family("bulb.local") == socket.AF_UNSPEC
+
+    def test_empty_string_is_unspecified(self):
+        assert address_family("") == socket.AF_UNSPEC
+
+
+class TestMacToIpv6LinkLocal:
+    # EUI-64: flip the universal/local bit and insert fffe in the
+    # middle of the MAC, so d0:73:d5:01:02:03 -> d273:d5ff:fe01:0203.
+    EUI64 = "d273:d5ff:fe01:0203"
+
+    def _addr(self, prefix):
+        return mac_to_ipv6_linklocal("d0:73:d5:01:02:03", prefix)
+
+    def test_default_prefix(self):
+        # The documented default used to produce an invalid
+        # triple-colon address ("fe80:::...").
+        assert mac_to_ipv6_linklocal("d0:73:d5:01:02:03") == "fe80::" + self.EUI64
+
+    def test_link_local_prefix_forms(self):
+        # All conventional spellings of the link-local prefix work.
+        for prefix in ("fe80", "fe80:", "fe80::"):
+            assert self._addr(prefix) == "fe80::" + self.EUI64
+
+    def test_full_64bit_prefix_without_trailing_colon(self):
+        # The form documented by the CLI help (--ipv6prefix).
+        assert self._addr("fd00:1:2:3") == "fd00:1:2:3:" + self.EUI64
+
+    def test_full_64bit_prefix_with_trailing_colon(self):
+        assert self._addr("fd00:1:2:3:") == "fd00:1:2:3:" + self.EUI64
+
+    def test_short_prefix_is_zero_filled(self):
+        # The README's "/48 prefix with a trailing colon" form.
+        assert self._addr("fd00:1:2:") == "fd00:1:2::" + self.EUI64
+
+    def test_compressed_prefix(self):
+        assert self._addr("fd00::3") == "fd00::3:" + self.EUI64
+
+    def test_all_forms_are_valid_ipv6(self):
+        for prefix in (
+            "fe80",
+            "fe80:",
+            "fe80::",
+            "fd00:1:2:3",
+            "fd00:1:2:3:",
+            "fd00:1:2:",
+            "fd00::3",
+        ):
+            addr = self._addr(prefix)
+            socket.inet_pton(socket.AF_INET6, addr)
+            assert address_family(addr) == socket.AF_INET6

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -8,7 +8,9 @@ message flow through Light/Device.
 """
 
 import asyncio
+import errno
 import socket
+from unittest import mock
 
 import pytest
 
@@ -139,6 +141,48 @@ class TestLIFXConnection:
             assert conn.device.mac_addr == MAC
         finally:
             conn.async_stop()
+
+
+class TestConnectionLifecycle:
+    """async_stop() must be safe whenever a caller tears down a connection.
+
+    When an IPv6 (Thread) route is missing, endpoint creation raises
+    OSError before a transport exists. Callers clean up by calling
+    async_stop(), which must not raise and must not mask the setup error.
+    """
+
+    async def test_async_stop_before_setup_is_noop(self):
+        conn = LIFXConnection("127.0.0.1", MAC)
+        conn.async_stop()
+        assert conn.transport is None
+
+    async def test_async_stop_after_failed_setup_does_not_mask_error(self):
+        conn = LIFXConnection("::1", MAC)
+        loop = asyncio.get_running_loop()
+        error = OSError(errno.ENETUNREACH, "Network is unreachable")
+        with mock.patch.object(loop, "create_datagram_endpoint", side_effect=error):
+            with pytest.raises(OSError) as excinfo:
+                await conn.async_setup()
+        assert excinfo.value is error
+        conn.async_stop()
+
+    async def test_async_stop_closes_transport(self):
+        conn = LIFXConnection("127.0.0.1", MAC)
+        await conn.async_setup()
+        transport = conn.transport
+        conn.async_stop()
+        assert transport.is_closing()
+        assert conn.transport is None
+
+    async def test_repeated_async_stop_closes_once(self):
+        conn = LIFXConnection("127.0.0.1", MAC)
+        await conn.async_setup()
+        transport = conn.transport
+        with mock.patch.object(transport, "close", wraps=transport.close) as close_mock:
+            conn.async_stop()
+            conn.async_stop()
+        assert close_mock.call_count == 1
+        assert transport.is_closing()
 
 
 class TestRequestResponse:

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,0 +1,190 @@
+"""Tests for unicast device connections over IPv4 and IPv6.
+
+Thread-connected LIFX devices have no IPv4 address and are reachable only
+via IPv6 through a Thread border router, so the unicast connection path
+must work for both address families. These tests run a minimal fake LIFX
+device on the loopback interface and exercise the full request/response
+message flow through Light/Device.
+"""
+
+import asyncio
+import socket
+
+import pytest
+
+from aiolifx.aiolifx import UDP_BROADCAST_PORT, Light, address_family
+from aiolifx.connection import LIFXConnection
+from aiolifx.msgtypes import (
+    GetHostFirmware,
+    GetLabel,
+    StateHostFirmware,
+    StateLabel,
+)
+from aiolifx.unpack import unpack_lifx_message
+
+MAC = "d0:73:d5:01:02:03"
+
+
+def _ipv6_loopback_available():
+    if not socket.has_ipv6:
+        return False
+    try:
+        sock = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM)
+        sock.bind(("::1", 0))
+        sock.close()
+        return True
+    except OSError:
+        return False
+
+
+requires_ipv6 = pytest.mark.skipif(
+    not _ipv6_loopback_available(), reason="IPv6 loopback not available"
+)
+
+
+class FakeLifxDevice(asyncio.DatagramProtocol):
+    """Minimal LIFX device answering label and firmware requests."""
+
+    def __init__(self, label=b"Fake Bulb"):
+        self.label = label
+        self.transport = None
+        self.requests = []
+
+    def connection_made(self, transport):
+        self.transport = transport
+
+    def datagram_received(self, data, addr):
+        request = unpack_lifx_message(data)
+        self.requests.append(request)
+        if isinstance(request, GetLabel):
+            reply = StateLabel(
+                request.target_addr,
+                request.source_id,
+                request.seq_num,
+                {"label": self.label},
+            )
+        elif isinstance(request, GetHostFirmware):
+            reply = StateHostFirmware(
+                request.target_addr,
+                request.source_id,
+                request.seq_num,
+                {"build": 0, "reserved1": 0, "version": (4 << 16) | 200},
+            )
+        else:
+            return
+        self.transport.sendto(reply.generate_packed_message(), addr)
+
+
+async def _start_fake_device(host):
+    loop = asyncio.get_running_loop()
+    transport, protocol = await loop.create_datagram_endpoint(
+        FakeLifxDevice, family=address_family(host), local_addr=(host, 0)
+    )
+    port = transport.get_extra_info("sockname")[1]
+    return transport, protocol, port
+
+
+async def _connect_light(host, port):
+    """Connect a Light the same way LIFXConnection.async_setup does."""
+    loop = asyncio.get_running_loop()
+    transport, light = await loop.create_datagram_endpoint(
+        lambda: Light(loop, MAC, host, port),
+        family=address_family(host),
+        remote_addr=(host, port),
+    )
+    return transport, light
+
+
+async def _get_label(light):
+    event = asyncio.Event()
+    light.get_label(callb=lambda dev, resp: event.set())
+    await asyncio.wait_for(event.wait(), timeout=5)
+    return light.label
+
+
+class TestLIFXConnection:
+    async def test_ipv4_socket_family(self):
+        conn = LIFXConnection("127.0.0.1", MAC)
+        await conn.async_setup()
+        try:
+            sock = conn.transport.get_extra_info("socket")
+            assert sock.family == socket.AF_INET
+            assert conn.transport.get_extra_info("peername") == (
+                "127.0.0.1",
+                UDP_BROADCAST_PORT,
+            )
+        finally:
+            conn.async_stop()
+
+    @requires_ipv6
+    async def test_ipv6_socket_family(self):
+        conn = LIFXConnection("::1", MAC)
+        await conn.async_setup()
+        try:
+            sock = conn.transport.get_extra_info("socket")
+            assert sock.family == socket.AF_INET6
+            assert conn.transport.get_extra_info("peername")[:2] == (
+                "::1",
+                UDP_BROADCAST_PORT,
+            )
+        finally:
+            conn.async_stop()
+
+    @requires_ipv6
+    async def test_ipv6_device_attributes(self):
+        conn = LIFXConnection("::1", MAC)
+        await conn.async_setup()
+        try:
+            assert conn.device.ip_addr == "::1"
+            assert conn.device.mac_addr == MAC
+        finally:
+            conn.async_stop()
+
+
+class TestRequestResponse:
+    async def test_ipv4_label_round_trip(self):
+        server_transport, server, port = await _start_fake_device("127.0.0.1")
+        transport, light = await _connect_light("127.0.0.1", port)
+        try:
+            assert await _get_label(light) == "Fake Bulb"
+        finally:
+            transport.close()
+            server_transport.close()
+
+    @requires_ipv6
+    async def test_ipv6_label_round_trip(self):
+        server_transport, server, port = await _start_fake_device("::1")
+        transport, light = await _connect_light("::1", port)
+        try:
+            assert await _get_label(light) == "Fake Bulb"
+        finally:
+            transport.close()
+            server_transport.close()
+
+    @requires_ipv6
+    async def test_ipv6_firmware_round_trip(self):
+        server_transport, server, port = await _start_fake_device("::1")
+        transport, light = await _connect_light("::1", port)
+        try:
+            event = asyncio.Event()
+            light.get_hostfirmware(callb=lambda dev, resp: event.set())
+            await asyncio.wait_for(event.wait(), timeout=5)
+            assert light.host_firmware_version == "4.200"
+        finally:
+            transport.close()
+            server_transport.close()
+
+    @requires_ipv6
+    async def test_ipv6_multiple_requests_share_connection(self):
+        server_transport, server, port = await _start_fake_device("::1")
+        transport, light = await _connect_light("::1", port)
+        try:
+            assert await _get_label(light) == "Fake Bulb"
+            event = asyncio.Event()
+            light.get_hostfirmware(callb=lambda dev, resp: event.set())
+            await asyncio.wait_for(event.wait(), timeout=5)
+            assert light.host_firmware_version == "4.200"
+            assert len(server.requests) == 2
+        finally:
+            transport.close()
+            server_transport.close()

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,0 +1,141 @@
+"""Tests for LifxDiscovery address family and remote address selection."""
+
+import asyncio
+import socket
+
+from aiolifx.aiolifx import UDP_BROADCAST_PORT, LifxDiscovery
+from aiolifx.message import BROADCAST_MAC
+from aiolifx.msgtypes import StateService
+
+MAC = "d0:73:d5:01:02:03"
+SOURCE_ID = 12345
+
+
+class RecordingLoop:
+    """Stand-in loop that records create_datagram_endpoint arguments."""
+
+    def __init__(self):
+        self.endpoints = []
+
+    def create_datagram_endpoint(self, factory, **kwargs):
+        self.endpoints.append(kwargs)
+
+        async def coro():
+            return None, factory()
+
+        return coro()
+
+
+def state_service_packet(mac_addr=MAC, port=UDP_BROADCAST_PORT):
+    """Build the wire format of a device's StateService discovery answer."""
+    return StateService(
+        mac_addr, SOURCE_ID, seq_num=0, payload={"service": 1, "port": port}
+    ).generate_packed_message()
+
+
+def make_discovery(loop, **kwargs):
+    discovery = LifxDiscovery(loop, parent=None, **kwargs)
+    return discovery
+
+
+class TestDatagramReceived:
+    async def test_ipv4_response_uses_af_inet(self):
+        loop = RecordingLoop()
+        discovery = make_discovery(loop)
+        discovery.datagram_received(
+            state_service_packet(), ("192.168.1.50", UDP_BROADCAST_PORT)
+        )
+        await asyncio.sleep(0)
+        assert len(loop.endpoints) == 1
+        endpoint = loop.endpoints[0]
+        assert endpoint["family"] == socket.AF_INET
+        assert endpoint["remote_addr"] == ("192.168.1.50", UDP_BROADCAST_PORT)
+        light = discovery.lights[MAC]
+        assert light.ip_addr == "192.168.1.50"
+        assert light.port == UDP_BROADCAST_PORT
+
+    async def test_ipv6_response_uses_af_inet6(self):
+        # A discovery answer arriving over IPv6 comes with a 4-tuple
+        # address and must be connected back to with an IPv6 socket.
+        loop = RecordingLoop()
+        discovery = make_discovery(loop)
+        ipv6 = "fd12:3456:789a:1:2:3:4:5"
+        discovery.datagram_received(
+            state_service_packet(), (ipv6, UDP_BROADCAST_PORT, 0, 0)
+        )
+        await asyncio.sleep(0)
+        endpoint = loop.endpoints[0]
+        assert endpoint["family"] == socket.AF_INET6
+        assert endpoint["remote_addr"] == (ipv6, UDP_BROADCAST_PORT)
+        assert discovery.lights[MAC].ip_addr == ipv6
+
+    async def test_ipv6prefix_uses_eui64_link_local(self):
+        loop = RecordingLoop()
+        discovery = make_discovery(loop, ipv6prefix="fe80::")
+        discovery.datagram_received(
+            state_service_packet(), ("192.168.1.50", UDP_BROADCAST_PORT)
+        )
+        await asyncio.sleep(0)
+        endpoint = loop.endpoints[0]
+        assert endpoint["family"] == socket.AF_INET6
+        remote_ip = endpoint["remote_addr"][0]
+        assert remote_ip == "fe80::d273:d5ff:fe01:0203"
+        # The synthesized address must be parseable.
+        socket.inet_pton(socket.AF_INET6, remote_ip)
+
+    async def test_broadcast_mac_ignored(self):
+        loop = RecordingLoop()
+        discovery = make_discovery(loop)
+        discovery.datagram_received(
+            state_service_packet(mac_addr=BROADCAST_MAC),
+            ("192.168.1.50", UDP_BROADCAST_PORT),
+        )
+        await asyncio.sleep(0)
+        assert loop.endpoints == []
+        assert discovery.lights == {}
+
+    async def test_custom_service_port_preserved(self):
+        loop = RecordingLoop()
+        discovery = make_discovery(loop)
+        discovery.datagram_received(
+            state_service_packet(port=56701), ("192.168.1.50", UDP_BROADCAST_PORT)
+        )
+        await asyncio.sleep(0)
+        assert loop.endpoints[0]["remote_addr"] == ("192.168.1.50", 56701)
+
+    async def test_rediscovery_updates_address_of_unregistered_light(self):
+        # A known but unregistered light rediscovered at a new address
+        # must be reconnected to that address with the matching family.
+        loop = RecordingLoop()
+        discovery = make_discovery(loop)
+        discovery.datagram_received(
+            state_service_packet(), ("192.168.1.50", UDP_BROADCAST_PORT)
+        )
+        await asyncio.sleep(0)
+        light = discovery.lights[MAC]
+        assert not light.registered
+        discovery.datagram_received(
+            state_service_packet(), ("192.168.1.99", UDP_BROADCAST_PORT)
+        )
+        await asyncio.sleep(0)
+        assert discovery.lights[MAC] is light
+        assert light.ip_addr == "192.168.1.99"
+        assert len(loop.endpoints) == 2
+        assert loop.endpoints[1]["family"] == socket.AF_INET
+        assert loop.endpoints[1]["remote_addr"] == ("192.168.1.99", UDP_BROADCAST_PORT)
+
+    async def test_rediscovery_of_registered_light_is_ignored(self):
+        loop = RecordingLoop()
+        discovery = make_discovery(loop)
+        discovery.datagram_received(
+            state_service_packet(), ("192.168.1.50", UDP_BROADCAST_PORT)
+        )
+        await asyncio.sleep(0)
+        light = discovery.lights[MAC]
+        light.registered = True
+        discovery.datagram_received(
+            state_service_packet(), ("192.168.1.99", UDP_BROADCAST_PORT)
+        )
+        await asyncio.sleep(0)
+        assert light.ip_addr == "192.168.1.50"
+        assert len(loop.endpoints) == 1

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -1,0 +1,59 @@
+"""Opt-in tests against real devices on the local network.
+
+These are skipped unless the corresponding environment variables are set:
+
+    AIOLIFX_LIVE_HOST / AIOLIFX_LIVE_MAC
+        An IPv4 (WiFi) device to test against.
+    AIOLIFX_LIVE_HOST6 / AIOLIFX_LIVE_MAC6
+        An IPv6 (e.g. Thread, via a border router) device to test against.
+
+Example:
+    AIOLIFX_LIVE_HOST6=fd12:3456:789a:1:2:3:4:5 \
+    AIOLIFX_LIVE_MAC6=d0:73:d5:01:02:03 pytest tests/test_live.py
+"""
+
+import asyncio
+import os
+import socket
+
+import pytest
+
+from aiolifx.connection import LIFXConnection
+
+
+async def _check_device(host, mac, family):
+    conn = LIFXConnection(host, mac)
+    await conn.async_setup()
+    try:
+        sock = conn.transport.get_extra_info("socket")
+        assert sock.family == family
+        event = asyncio.Event()
+        conn.device.get_label(callb=lambda dev, resp: event.set())
+        await asyncio.wait_for(event.wait(), timeout=5)
+        assert conn.device.label
+    finally:
+        conn.async_stop()
+
+
+@pytest.mark.skipif(
+    not (os.environ.get("AIOLIFX_LIVE_HOST") and os.environ.get("AIOLIFX_LIVE_MAC")),
+    reason="AIOLIFX_LIVE_HOST/AIOLIFX_LIVE_MAC not set",
+)
+async def test_live_ipv4_device():
+    await _check_device(
+        os.environ["AIOLIFX_LIVE_HOST"],
+        os.environ["AIOLIFX_LIVE_MAC"],
+        socket.AF_INET,
+    )
+
+
+@pytest.mark.skipif(
+    not (os.environ.get("AIOLIFX_LIVE_HOST6") and os.environ.get("AIOLIFX_LIVE_MAC6")),
+    reason="AIOLIFX_LIVE_HOST6/AIOLIFX_LIVE_MAC6 not set",
+)
+async def test_live_ipv6_device():
+    await _check_device(
+        os.environ["AIOLIFX_LIVE_HOST6"],
+        os.environ["AIOLIFX_LIVE_MAC6"],
+        socket.AF_INET6,
+    )


### PR DESCRIPTION
## Motivation

Thread-connected LIFX devices (e.g. the newer firmware version with Thread support) have no IPv4 address. They are reachable only via IPv6 through a Thread border router, which also advertises them over mDNS (`_lifx._udp.local.`) on the device's behalf. Today aiolifx can talk to such a device only by accident: `LIFXConnection` passes no socket family, so an IPv6 literal happens to work, but nothing pins or tests that path, and the discovery code hardcodes `AF_INET`.

This PR makes the unicast paths explicitly IPv6-capable, with tests, while keeping the public API unchanged.

## Changes

- **New `address_family()` helper** (`aiolifx/aiolifx.py`): IP literals map to their exact socket family (`AF_INET`/`AF_INET6`, with zone-id handling for scoped link-local literals); anything else (hostnames) maps to `AF_UNSPEC` so `getaddrinfo` keeps choosing the family exactly as before.
- **`LIFXConnection.async_setup` and `LifxDiscovery.datagram_received`** now pass that family when creating device endpoints, so connecting to a Thread device's IPv6 address (e.g. learned via mDNS/zeroconf) deterministically gets an `AF_INET6` socket.
- **`LIFXConnection.async_stop()` is now null-safe and idempotent** (`aiolifx/connection.py`): it used to `assert self.transport is not None`, so cleanup after a failed `async_setup()` raised `AssertionError` and masked the original error. This matters specifically for IPv6 (Thread) devices: an address under a temporarily vanished Thread route fails UDP endpoint creation immediately and locally with an `OSError` (e.g. `ENETUNREACH`) — unlike a stale IPv4 LAN address, where the connected socket is created fine and the failure only shows up later as a request timeout. Callers that catch that `OSError` and tear down the partially initialized connection (e.g. Home Assistant classifying it as a retryable setup failure) must be able to call `async_stop()` without a second exception masking the first. It is now a no-op before setup and after a failed setup, closes the transport exactly once, is safe to call repeatedly, and remains synchronous. No tasks, timers, packets, dependencies, or signature changes.
- **Bug fix in `mac_to_ipv6_linklocal`**: with the documented default prefix (`"fe80::"`) it produced an invalid triple-colon address (`fe80:::…`) that `inet_pton` rejects. The join is now normalized so every conventional prefix form yields a valid address — bare /64 (`fd00:1:2:3`, the form the CLI help documents), trailing-colon forms, short prefixes (zero-filled), and compressed prefixes (`fd00::3`). All forms that worked before produce identical output; previously broken forms now work.
- **Docs**: note that the `ipv6prefix` EUI-64 mechanism cannot find Thread devices (their addresses are not EUI-64-derived and they never answer IPv4 broadcast) — those should be connected directly by IPv6 address; README section on IPv6 updated accordingly.
- **Tests**: first pytest suite for the repo (`pip install .[test] && pytest`) — 33 hermetic tests covering family selection, every documented `ipv6prefix` form, discovery address handling including the rediscovery path, connection lifecycle (`async_stop()` before setup, after a failed setup, and repeated calls), and full request/response round trips over IPv4 and IPv6 loopback against a fake LIFX device speaking the real wire format. Live-hardware tests are opt-in via environment variables (`tests/test_live.py`).

## Verification

- **Real hardware**: broadcast discovery still finds a 50+ device WiFi fleet unchanged; a Thread downlight (host firmware 4.200) was reached at its border-router ULA over an `AF_INET6` socket — label and firmware queries round-trip correctly. Re-verified after the lifecycle change: the opt-in live tests pass against both a WiFi bulb (IPv4) and the Thread downlight (IPv6), including the `async_stop()` teardown path.
- **Test suite**: 33 passed; 20 consecutive runs with zero flakiness; clean under `PYTHONASYNCIODEBUG=1` with `ResourceWarning`/`DeprecationWarning` as errors.
- **Home Assistant compatibility** (largest downstream consumer, pins `aiolifx==1.2.2`): HA core's full `tests/components/lifx` suite (dev branch) passes **with stock 1.2.2 and with this branch installed** — byte-for-byte identical results at the initial verification (72/72), re-run green after the `async_stop()` change, and every symbol HA imports is unchanged.
- **black**: `black --check .` passes (matches this repo's CI).

## Suggested follow-up: CI for the test suite

Pushing workflow files needs a token scope the author's setup lacked, so this PR doesn't add CI. If you'd like the suite to run on PRs, this drop-in works as `.github/workflows/pytest.yml`:

```yaml
name: pytest

on: [push, pull_request]

jobs:
  pytest:
    runs-on: ubuntu-latest
    strategy:
      matrix:
        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
    steps:
      - uses: actions/checkout@v4
      - uses: actions/setup-python@v5
        with:
          python-version: ${{ matrix.python-version }}
      - name: Install
        run: pip install .[test]
      - name: Run tests
        run: pytest tests/
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
