### PR TITLE
feat: add ambient light sensor support (SensorGetAmbientLight/SensorStateAmbientLight)

### DIFF
--- a/aiolifx/aiolifx.py
+++ b/aiolifx/aiolifx.py
@@ -157,6 +157,7 @@ class Device(aio.DatagramProtocol):
         self.host_firmware_build_timestamp = None
         self.wifi_firmware_version = None
         self.wifi_firmware_build_timestamp = None
+        self.ambient_light = None
         self.lastmsg = datetime.datetime.now()
 
     def seq_next(self):
@@ -729,6 +730,35 @@ class Device(aio.DatagramProtocol):
         """
         response = self.req_with_resp(GetWifiInfo, StateWifiInfo, callb=callb)
         return None
+
+    # Too volatile to be saved
+    def get_ambient_light(self, callb=None):
+        """Convenience method to request the ambient light level from the device
+
+        This method will request the ambient light level, in lux, as measured by
+        the device's sensor. A request is always sent to the device as the value
+        is volatile; the last known value is returned and self.ambient_light is
+        updated when the SensorStateAmbientLight response arrives.
+
+        Note that only some devices have an ambient light sensor (e.g. the LIFX
+        Switch). Devices without a sensor still respond, but always report 0.0.
+        The reported value is unreliable if the device's own light is on.
+
+            :param callb: Callable to be used when the response is received. If not set,
+                        self.resp_set_sensorambientlight will be used.
+            :type callb: callable
+            :returns: The last known ambient light level, in lux
+            :rtype: float
+        """
+        response = self.req_with_resp(
+            SensorGetAmbientLight, SensorStateAmbientLight, callb=callb
+        )
+        return self.ambient_light
+
+    def resp_set_sensorambientlight(self, resp):
+        """Default callback for get_ambient_light"""
+        if resp:
+            self.ambient_light = resp.lux
 
     def get_hostfirmware(self, callb=None):
         """Convenience method to request the device firmware info from the device

--- a/aiolifx/msgtypes.py
+++ b/aiolifx/msgtypes.py
@@ -1340,6 +1340,56 @@ class StateLastHevCycleResult(Message):
         return LAST_HEV_CYCLE_RESULT.get(self.result, "UNKNOWN")
 
 
+##### SENSOR MESSAGES #####
+
+
+class SensorGetAmbientLight(Message):
+    def __init__(
+        self,
+        target_addr,
+        source_id,
+        seq_num,
+        payload={},
+        ack_requested=False,
+        response_requested=False,
+    ):
+        super(SensorGetAmbientLight, self).__init__(
+            MSG_IDS[SensorGetAmbientLight],
+            target_addr,
+            source_id,
+            seq_num,
+            ack_requested,
+            response_requested,
+        )
+
+
+class SensorStateAmbientLight(Message):
+    def __init__(
+        self,
+        target_addr,
+        source_id,
+        seq_num,
+        payload,
+        ack_requested=False,
+        response_requested=False,
+    ):
+        self.lux = payload["lux"]
+        super(SensorStateAmbientLight, self).__init__(
+            MSG_IDS[SensorStateAmbientLight],
+            target_addr,
+            source_id,
+            seq_num,
+            ack_requested,
+            response_requested,
+        )
+
+    def get_payload(self):
+        self.payload_fields.append(("Lux", self.lux))
+        lux = little_endian(bitstring.pack("float:32", self.lux))
+        payload = lux
+        return payload
+
+
 ##### MULTIZONE MESSAGES #####
 
 
@@ -2464,6 +2514,8 @@ MSG_IDS = {
     StateHevCycleConfiguration: 147,
     GetLastHevCycleResult: 148,
     StateLastHevCycleResult: 149,
+    SensorGetAmbientLight: 401,
+    SensorStateAmbientLight: 402,
     MultiZoneSetColorZones: 501,
     MultiZoneGetColorZones: 502,
     MultiZoneStateZone: 503,

--- a/aiolifx/unpack.py
+++ b/aiolifx/unpack.py
@@ -379,6 +379,18 @@ def unpack_lifx_message(packed_message):
             target_addr, source_id, seq_num, payload, ack_requested, response_requested
         )
 
+    elif message_type == MSG_IDS[SensorGetAmbientLight]:  # 401
+        message = SensorGetAmbientLight(
+            target_addr, source_id, seq_num, {}, ack_requested, response_requested
+        )
+
+    elif message_type == MSG_IDS[SensorStateAmbientLight]:  # 402
+        lux = struct.unpack("<f", payload_str[0:4])[0]
+        payload = {"lux": lux}
+        message = SensorStateAmbientLight(
+            target_addr, source_id, seq_num, payload, ack_requested, response_requested
+        )
+
     elif message_type == MSG_IDS[MultiZoneStateZone]:  # 503
         count = struct.unpack("c", payload_str[0:1])[0]
         count = ord(count)  # 8 bit


### PR DESCRIPTION
## Summary

Adds support for the ambient light sensor found in some LIFX devices — most notably the LIFX Switch:

- **`msgtypes.py`**: new `SensorGetAmbientLight` (401) and `SensorStateAmbientLight` (402) message classes. The State payload is a single little-endian float32 `lux`.
- **`unpack.py`**: handlers for both message types.
- **`aiolifx.py`**: `Device.get_ambient_light(callb=None)` following the existing volatile-value pattern (`get_wifiinfo`): a request is always sent, the last known value is returned, and the default callback (`resp_set_sensorambientlight`, dispatched automatically by the `State*` naming convention) caches the reading on `device.ambient_light`.

The message transfers **only the device-reported reading, unmodified** — no scaling or calibration is applied in the library (observations about real-world calibration are documented below for reference, not implemented).

```python
def my_callb(device, resp):
    print(f"{device.label}: {resp.lux} lx")

device.get_ambient_light(my_callb)
# or poll device.ambient_light after the default callback has cached it
```

> [!WARNING]
> It's worth flagging that this feature is unsupported by LIFX. The value reported is not true lux — it is reduced by around 20–25× as the light passes through a layer of glass/coating in front of the sensor. White and black switches may report different values.

## Protocol references

- [SensorGetAmbientLight (401)](https://lan.developer.lifx.com/docs/querying-the-device-for-data#sensorgetambientlight---packet-401)
- [SensorStateAmbientLight (402)](https://lan.developer.lifx.com/docs/information-messages#sensorstateambientlight---packet-402)

The official docs mark this as a legacy feature supported by a limited number of devices, and note the value is unreliable while the device's own light output is on (less of an issue for the Switch, whose only light output is its button backlight).

## Live verification

Tested on a home LAN with ~52 LIFX devices. All 12 LIFX Switches (pid 89 and pid 115) reply to packet 401 with a 402 carrying a live, plausible lux reading (evening, indoors):

| Switch (pid) | lux | Switch (pid) | lux |
|---|---|---|---|
| Kitchen Entrance (115) | 23.06 | Kids (89) | 2.96 |
| Back Door (89) | 6.71 | Bathroom (89) | 2.93 |
| Ensuite (115) | 5.68 | Study (89) | 2.78 |
| Porch (89) | 5.28 | Arch (115) | 1.66 |
| Living (89) | 3.77 | Hallway (89) | 1.09 |
| Pantry (89, dark closed room) | 0.00 | Master Bedroom (89) | 1.09 |

Repeat sampling shows live sensor behaviour — readings drift by ~0.03 lx between 10-second samples in lit rooms and track real changes (see screenshots below).

The end-to-end path was also verified through this branch's actual code: `Device.get_ambient_light()` → 401 → 402 → auto-dispatched `resp_set_sensorambientlight` → `device.ambient_light` populated, plus a pack→unpack round-trip of both new message types.

### Screenshot: blinds closing (2 s polling, Study Switch)

Readings fall smoothly from ~22 lx to ~1.8 lx as the room darkens:

![Lux trace while blinds close](https://raw.githubusercontent.com/redding1/aiolifx/assets-ambient-light-sensor/ambient-light-blinds-closing.png)

### Screenshot: room lights switched on

Blinds closed, then artificial lighting (comfortable working level) settles around 6–7.4 lx:

![Lux trace with lights on](https://raw.githubusercontent.com/redding1/aiolifx/assets-ambient-light-sensor/ambient-light-lights-on.png)

## Caveats worth knowing (informational — not implemented in code)

1. **Replying to 401 does not prove a sensor exists.** Every device tested (bulbs, strips, downlights) answers with a 402, but devices without a sensor report `0.0`. Capability detection therefore can't be "does it reply"; consumers should treat 0.0 as "no sensor or dark" and/or gate on product.
2. **Readings are heavily attenuated.** Comparing sensor values against typical illuminance for the observed conditions suggests the Switch reads roughly 4–5% of true desk-level lux (sensor mounted vertically behind tinted plastic). A rough working conversion is `true lux ≈ 20–25 × reading`, but it varies with switch placement, so the library deliberately reports the raw device value only.
3. **Dark floor ≈ 1.09 lx.** In genuinely dark rooms the sensor bottoms out at a stable 1.085882 quantization step (possibly the switch's own button backlight); below that, readings stop being proportional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
